### PR TITLE
Generalize pit_loss to arbitrary shape and to retrieve the min perm

### DIFF
--- a/padertorch/ops/losses/loss.py
+++ b/padertorch/ops/losses/loss.py
@@ -114,9 +114,20 @@ def pit_loss(
         tensor(1.)
 
         >>> T, K, F = 4, 2, 5
-        >>> estimate, target = torch.ones(K, F, T), torch.zeros(K, F, T)
+        >>> estimate = torch.stack([torch.ones(F, T), torch.zeros(F, T)])
+        >>> target = estimate[(1, 0), :, :]
         >>> pit_loss(estimate, target, axis=0, return_permutation=True)
-        (tensor(1.), (0, 1))
+        (tensor(1.), (1, 0))
+
+        >>> K = 5
+        >>> estimate, target = torch.ones(K), torch.zeros(K)
+        >>> pit_loss(estimate, target, axis=0)
+        tensor(1.)
+
+        >>> A, B, K, C, F = 4, 5, 3, 100, 128
+        >>> estimate, target = torch.ones(A, B, K, C, F), torch.zeros(A, B, K, C, F)
+        >>> pit_loss(estimate, target, axis=-3)
+        tensor(1.)
     """
     axis = axis % estimate.ndimension()
     sources = estimate.size()[axis]

--- a/padertorch/ops/losses/loss.py
+++ b/padertorch/ops/losses/loss.py
@@ -10,6 +10,7 @@ import padertorch as pt
 __all__ = [
     'softmax_cross_entropy',
     'deep_clustering_loss',
+    'pit_loss',
     'pit_mse_loss',
     'kl_divergence',
 ]

--- a/padertorch/ops/losses/loss.py
+++ b/padertorch/ops/losses/loss.py
@@ -117,7 +117,7 @@ def pit_loss(
         >>> estimate = torch.stack([torch.ones(F, T), torch.zeros(F, T)])
         >>> target = estimate[(1, 0), :, :]
         >>> pit_loss(estimate, target, axis=0, return_permutation=True)
-        (tensor(1.), (1, 0))
+        (tensor(0.), (1, 0))
 
         >>> K = 5
         >>> estimate, target = torch.ones(K), torch.zeros(K)

--- a/padertorch/ops/losses/loss.py
+++ b/padertorch/ops/losses/loss.py
@@ -118,6 +118,7 @@ def pit_loss(
         >>> pit_loss(estimate, target, axis=0, return_permutation=True)
         (tensor(1.), (0, 1))
     """
+    axis = axis % estimate.ndimension()
     sources = estimate.size()[axis]
     assert sources < 30, f'Are you sure? sources={sources}'
     if loss_fn in [torch.nn.functional.cross_entropy]:

--- a/padertorch/ops/losses/loss.py
+++ b/padertorch/ops/losses/loss.py
@@ -132,17 +132,18 @@ def pit_loss(
             f'{estimate.size()} != {target.size()}'
         )
     candidates = []
-    filler = (slice(None),) * axis 
-    for permutation in itertools.permutations(range(sources)):
-        candidates.append((loss_fn(
+    filler = (slice(None),) * axis
+    permutations = list(itertools.permutations(range(sources)))
+    for permutation in permutations:
+        candidates.append(loss_fn(
             estimate[filler + (permutation, )],
             target
-        ), permutation))
+        ))
 
-    min_loss, min_perm = min(candidates, key=lambda x: x[0])
+    min_loss, idx = torch.min(torch.stack(candidates), dim=0)
 
     if return_permutation:
-        return min_loss, min_perm
+        return min_loss, permutations[int(idx)]
     else:
         return min_loss
 


### PR DESCRIPTION
This PR generalizes `pit_loss` to use an arbitrary shape and axis.

It now uses python `min` instead of `torch.min` to get both the min loss and permutation at the same time. I am not sure if this is good or not; it makes the code easier to read but slower (I think).