### PR TITLE
Remove dependency on matplotlib

### DIFF
--- a/padertorch/summary/tbx_utils.py
+++ b/padertorch/summary/tbx_utils.py
@@ -100,9 +100,18 @@ def spectrogram_to_image(signal, batch_first=False, color='viridis'):
         try:
             cmap = _spectrogram_to_image_cmap[color]
         except KeyError:
-            import matplotlib.pyplot as plt
-            cmap = plt.cm.get_cmap(color)
-            _spectrogram_to_image_cmap[color] = cmap
+            try:
+                import matplotlib.pyplot as plt
+                cmap = plt.cm.get_cmap(color)
+                _spectrogram_to_image_cmap[color] = cmap
+            except ImportError:
+                from warnings import warn
+                gray_scale = lambda x: x.transpose(1, 0)[None, ::-1, :]
+                warn('Since matplotlib is not installed, all images are '
+                     'switched to grey scale')
+                _spectrogram_to_image_cmap[color] = gray_scale
+                # gray image
+                return gray_scale(signal)
 
         return cmap(signal).transpose(2, 1, 0)[:, ::-1, :]
     else:

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ setup(
         'einops',
         'progressbar2',
         'natsort',
-        'paderbox[all] @ git+http://github.com/fgnt/paderbox',
+        'matplotlib',
+        'paderbox @ git+http://github.com/fgnt/paderbox',
     ],
 
     # Installation problems in a clean, new environment:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 # testing dependencies
-test = ['coverage', 'pylint', 'sacred', 'appdirs',
+test = ['pytest', 'coverage', 'pylint', 'sacred', 'appdirs',
         'protobuf3_to_dict', 'torchvision']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
         'einops',
         'progressbar2',
         'natsort',
-        'matplotlib',
         'paderbox @ git+http://github.com/fgnt/paderbox',
     ],
 


### PR DESCRIPTION
The dependencies on paderbox[all] results from our use of matplotlib.

In general I would like to remove the matplotlib dependency since we only use it to specify colors in summary plots.
Therefore, I added a fallback to gray scale if matplotlib is not installed and a warning.