### PR TITLE
[WIP] add multi gpu support

### DIFF
--- a/padertorch/contrib/examples/multi_gpu/train.py
+++ b/padertorch/contrib/examples/multi_gpu/train.py
@@ -1,0 +1,158 @@
+"""
+A basic example to demonstrate, how DataParallel can be used in padertorch.
+We recommend to use the build in support for data parallel, because it uses the
+virtual mini batch instead of the real mini batch to distribute the work on
+multiple GPUs.
+
+The code is inspired from the examples in
+https://pytorch.org/tutorials/beginner/blitz/data_parallel_tutorial.html
+Authors: Sung Kim and Jenny Kang
+
+Use the following command:
+
+    python train.py with storage_root=/path/to/dir
+
+to start the experiment an take a look at the
+
+    forward shape: torch.Size([11, 28])
+    forward shape: torch.Size([12, 28])
+    review shape: torch.Size([23, 28])
+
+in the output. You should see, that the shape in the forward is different
+from the shape in the review. Also the forward is more offten called than the
+review.
+"""
+from pathlib import Path
+import numpy as np
+
+import torch
+import torch.nn
+
+import sacred
+import sacred.commands
+
+import paderbox as pb
+import padertorch as pt
+from padertorch.modules import fully_connected_stack
+
+from padertorch.contrib.cb.io import get_new_folder
+
+experiment = sacred.Experiment()
+
+
+class MyModel(pt.base.Model):
+
+    def __init__(self, net):
+        super().__init__()
+        self.net = net
+
+    def forward(self, example):
+        print("\tforward shape:", example['feature'].size())
+        out = self.net(example['feature'])
+        return out
+
+    def review(self, example, prediction):
+        print("\treview shape:", example['feature'].size())
+        loss = torch.nn.CrossEntropyLoss()(prediction, example['label'])
+
+        with torch.no_grad():
+            _, predicted = torch.max(prediction, 1)
+            acc = (predicted == example['label']).sum().item() / len(example['label'])
+
+        return dict(loss=loss, scalars={'Accuracy': acc})
+
+
+@experiment.config
+def config():
+    epochs = 2
+    storage_root = None
+
+    features = 28
+    classes = 10
+    
+    trainer = pb.utils.nested.deflatten({
+        'model.factory': MyModel,
+        'model.net.factory': fully_connected_stack,
+        'model.net.input_size': features,
+        'model.net.hidden_size': [10],
+        'model.net.output_size': classes,
+        'model.net.activation': 'relu',
+        'model.net.dropout': 0.,
+
+        'optimizer.factory': pt.optimizer.SGD,
+        'summary_trigger': (1, 'epoch'),
+        'checkpoint_trigger': (1, 'epoch'),
+        'stop_trigger': (2, 'epoch'),
+        'storage_dir': str(get_new_folder(storage_root, mkdir=False)),
+    })
+    pt.Trainer.get_config(trainer)
+
+    experiment.observers.append(sacred.observers.FileStorageObserver.create(
+        Path(trainer['storage_dir']) / 'sacred'
+    ))
+
+
+def get_random_dataset(length, features=28, classes=10):
+    """
+    >>> from paderbox.utils.pretty import pprint
+    >>> np.random.seed(0)
+    >>> pprint(get_random_dataset(10)[0], max_array_length=10)
+    {'feature': array(shape=(25, 28), dtype=float32),
+     'label': array(shape=(25,), dtype=int64)}
+    """
+
+    dataset = []
+    for i in range(length):
+        frames = np.random.randint(20, 30)
+        label = np.random.randint(0, classes)
+        label = np.array([label] * frames, dtype=np.int64)
+        
+        dataset.append({
+            'feature': (label[:, None] + np.random.normal(size=(frames, features))).astype(np.float32),
+            'label': label,
+        })
+    
+    return dataset
+
+
+class DataParallel(torch.nn.DataParallel):
+    def __getattr__(self, attr):
+        """
+        Overwrite __getattr__ so the user does not recognize if the
+        model is wrapped by DataParallel, i.e. forward attribute access
+        to the model.
+        """
+        try:
+            # torch.nn.module overwrites __getattr__,
+            # hence first call super.
+            return super().__getattr__(attr)
+        except AttributeError:
+            pass
+        return getattr(self.module, attr)
+
+
+@experiment.automain
+def main(_run, _config, features, classes):
+    # Get Datasets
+    train_ds = get_random_dataset(10, features=features, classes=classes)
+    dev_ds = get_random_dataset(1, features=features, classes=classes)
+
+    sacred.commands.print_config(_run)
+    trainer: pt.Trainer = pt.Trainer.from_config(_config['trainer'])
+
+    pb.io.dump(_config, trainer.storage_dir / 'config.yaml')
+    pb.io.dump(_config, trainer.storage_dir / 'config.json')
+
+    if torch.cuda.device_count() > 1:
+        print("Let's use", torch.cuda.device_count(), "GPUs!")
+        # dim = 0 [30, xxx] -> [10, ...], [10, ...], [10, ...] on 3 GPUs
+        trainer.model = DataParallel(trainer.model)
+    else:
+        print('#' * 79)
+        print('WARNING: Could not find multiple GPUs !!!')
+        print('#' * 79)
+    print('torch.cuda.device_count()', torch.cuda.device_count())
+    print('torch.cuda.is_available()', torch.cuda.is_available())
+
+    trainer.register_validation_hook(validation_iterator=dev_ds)
+    trainer.train(train_ds)

--- a/padertorch/contrib/examples/multi_gpu/train.py
+++ b/padertorch/contrib/examples/multi_gpu/train.py
@@ -2,7 +2,13 @@
 A basic example to demonstrate, how DataParallel can be used in padertorch.
 We recommend to use the build in support for data parallel, because it uses the
 virtual mini batch instead of the real mini batch to distribute the work on
-multiple GPUs.
+multiple GPUs. Since it uses the code from torch.nn.DataParallel we expect,
+that when torch.nn.DataParallel works for you, the build in should also work.
+
+We observed some difficulties with torch.nn.DataParallel
+  https://github.com/pytorch/pytorch/issues/33552 RNNs do not have gradients while using DataParallel in 1.4.0
+At the moment we do not know with pytorch versions work without problems.
+
 
 The code is inspired from the examples in
 https://pytorch.org/tutorials/beginner/blitz/data_parallel_tutorial.html
@@ -12,7 +18,7 @@ Use the following command:
 
     python train.py with storage_root=/path/to/dir
 
-to start the experiment an take a look at the
+to start the experiment and take a look at the
 
     forward shape: torch.Size([11, 28])
     forward shape: torch.Size([12, 28])

--- a/padertorch/contrib/examples/tasnet/train.py
+++ b/padertorch/contrib/examples/tasnet/train.py
@@ -177,12 +177,17 @@ def prepare_iterable(
 
 @ex.capture
 def prepare_iterable_captured(
-        database_obj, dataset, batch_size, debug, chunk_size
+        database_obj, dataset, batch_size, debug, chunk_size,
+        iterator_slice=None,
 ):
+    if iterator_slice is None:
+        if debug:
+            iterator_slice = slice(0, 100, 1)
+
     return prepare_iterable(
         database_obj, dataset, batch_size, chunk_size,
         prefetch=not debug,
-        iterator_slice=slice(0, 100, 1) if debug else None
+        iterator_slice=iterator_slice,
     )
 
 

--- a/padertorch/contrib/examples/tasnet/train.py
+++ b/padertorch/contrib/examples/tasnet/train.py
@@ -12,6 +12,8 @@ from paderbox.io import load_audio
 from sacred import Experiment
 import sacred.commands
 
+# sacred.SETTINGS.CONFIG.READ_ONLY_CONFIG = False
+
 import os
 from pathlib import Path
 

--- a/padertorch/contrib/examples/tasnet/train.py
+++ b/padertorch/contrib/examples/tasnet/train.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from sacred.utils import InvalidConfigError, MissingConfigError
 
 import padertorch as pt
+import padertorch.contrib.examples.tasnet.tasnet
 import paderbox as pb
 import numpy as np
 
@@ -65,7 +66,7 @@ def config():
     # Start with an empty dict to allow tracking by Sacred
     trainer = {
         "model": {
-            "factory": 'padertorch.contrib.examples.tasnet.tasnet.TasNet',
+            "factory": pt.contrib.examples.tasnet.tasnet.TasNet,
         },
         "storage_dir": None,
         "optimizer": {

--- a/padertorch/contrib/examples/tasnet/train.py
+++ b/padertorch/contrib/examples/tasnet/train.py
@@ -3,8 +3,8 @@ Example call on NT infrastructure:
 
 export STORAGE=<your desired storage root>
 mkdir -p $STORAGE/pth_models/dprnn
-python -m padertorch.contrib.neumann.dual_path_rnn.train print_config
-python -m padertorch.contrib.neumann.dual_path_rnn.train
+python -m padertorch.contrib.examples.tasnet.train print_config
+python -m padertorch.contrib.examples.tasnet.train
 """
 import torch
 from paderbox.io import load_audio

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -731,7 +731,10 @@ class LRSchedulerHook(TriggeredHook):
     # https://github.com/pytorch/pytorch/pull/20203
     PYTORCH_ge_1_1 = LooseVersion(torch.__version__) >= '1.1.0'
 
-    def __init__(self, lr_scheduler, trigger=(1, 'epoch')):
+    def __init__(
+            self,
+            lr_scheduler: torch.optim.lr_scheduler._LRScheduler,
+            trigger=(1, 'epoch')):
         super().__init__(trigger)
         self.lr_scheduler = lr_scheduler
 

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -258,14 +258,18 @@ class SummaryHook(TriggeredHook):
         sum_time_per_iteration = np.sum(timer_dict.get('time_per_iteration', [0]))
         if sum_time_per_iteration > 0:
             for k in [
+                    'time_per_data_loading',
                     'time_per_to_device',
                     'time_per_forward',
                     'time_per_review',
                     'time_per_backward',
                     'time_per_optimize',
+                    'time_per_replicate',
+                    'time_per_parallel_apply',
+                    'time_per_gather',
             ]:
                 if k in timer_dict:
-                    summary_timings['time_rel_data_loading'] = \
+                    summary_timings[k.replace('_per_', '_rel_')] = \
                         np.sum(timer_dict.pop(k)) / sum_time_per_iteration
 
         summary_timings.update({

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -109,6 +109,21 @@ class Hook:
         """
         pass
 
+    def post_optimize(self, trainer: 'pt.Trainer', summary):
+        """
+        function is called after each optimize
+
+        Args:
+            trainer:
+            summary:
+                Contains things that are reported from the optimizer.
+                e.g. gradient norm and learning rate
+
+        Returns:
+
+        """
+        pass
+
     def close(self, trainer: 'pt.Trainer'):
         pass
 
@@ -182,8 +197,8 @@ class SummaryHook(TriggeredHook):
 
     def update_summary(self, review):
         allowed_keys = {
-            'loss',
-            'losses',
+            # 'loss',  # The trainer moves the loss and losses to scalars
+            # 'losses',
             'scalars',
             'histograms',
             'audios',
@@ -352,6 +367,9 @@ class SummaryHook(TriggeredHook):
 
     def post_step(self, trainer: 'pt.Trainer', example, model_out, review):
         self.update_summary(review)
+
+    def post_optimize(self, trainer : 'pt.Trainer', summary):
+        self.update_summary(summary)
 
     def close(self, trainer: 'pt.Trainer'):
         self.finalize_summary(trainer)

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -771,8 +771,11 @@ class ProgressBarHook(TriggeredHook):
             raise ValueError(f'unit {unit} is unknown,'
                              f' choose iteration or epoch')
         self.loss = None
-        self.pbar = tqdm(initial=1, total=max_iteration)
-
+        self.pbar = tqdm(initial=1, total=max_iteration, smoothing=1)
+        # smoothing:
+        #     Use "current/instantaneous speed", otherwise it is confusing when
+        #     you resume an experiment (start value is one and the first step
+        #     is to the value of the iteration counter).
 
     @property
     def priority(self):

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -579,7 +579,10 @@ class ValidationHook(SummaryHook):
         best_ckpt_path.symlink_to(self.ckpt_ranking[0][0])
 
     def close(self, trainer: 'pt.Trainer'):
-        self.set_best_symlink(trainer.checkpoint_dir)
+        if trainer.checkpoint_dir.exists():
+            # When checkpoint_dir does not exist, your training failed, before
+            # the first validation started
+            self.set_best_symlink(trainer.checkpoint_dir)
         ckpt_name = trainer.default_checkpoint_path().name
         if ckpt_name not in [ckpt[0] for ckpt in self.ckpt_ranking]:
             # add to ranking to make sure it is deleted after resume

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -196,12 +196,10 @@ class SummaryHook(TriggeredHook):
         redundant_keys = set(review.keys()) - allowed_keys
         assert len(redundant_keys) == 0, (redundant_keys, review.keys(), allowed_keys)
 
+        assert len(review) >= 1, review
         popped_review = {**review}  # copy for "pop"
 
         # note item is the pytorch function to get the value of a tensor
-        self.summary['scalars']['loss'].append(popped_review.pop('loss').item())
-        for key, loss in popped_review.pop('losses', dict()).items():
-            self.summary['scalars'][key].append(loss.item())
         for key, scalars in popped_review.pop('scalars', dict()).items():
             self.summary['scalars'][key].extend(self._to_list(scalars))
         for key, histogram in popped_review.pop('histograms', dict()).items():
@@ -526,7 +524,7 @@ class ValidationHook(SummaryHook):
         assert len(trainer.validate_timer.timings) == 0, trainer.validate_timer
         print('Starting Validation')
         at_least_one_value = False
-        for model_out, review in trainer.validate(self.iterator):
+        for example, model_out, review in trainer.validate(self.iterator):
             at_least_one_value = True
             self.update_summary(review)
         if not at_least_one_value:

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -369,7 +369,10 @@ class SummaryHook(TriggeredHook):
         self.update_summary(review)
 
     def post_optimize(self, trainer : 'pt.Trainer', summary):
-        self.update_summary(summary)
+        self.post_step(trainer, None, None, summary)
+        # self.update_summary(summary)
+        # Call post_step, so subclasses (e.g. ValidationHook) only need to
+        # overwrite the post step.
 
     def close(self, trainer: 'pt.Trainer'):
         self.finalize_summary(trainer)
@@ -551,6 +554,7 @@ class ValidationHook(SummaryHook):
             self.n_degradations = 0
 
     def post_step(self, trainer: 'pt.Trainer', example, model_out, review):
+        # Ignore super.
         if trainer.iteration == self.last_validation:
             # As CheckpointHook.pre_step is called after ValidationHook.pre_step
             # (which is necessary to save ValidationHook state),

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -275,18 +275,23 @@ class Trainer(Configurable):
         hooks = sorted(hooks, key=lambda h: h.priority, reverse=True)
 
         if len(device) >= 2:
+            import textwrap
             print(
                 'WARNING: You called padertorch.Trainer.train with multiple\n'
-                'devices. With this the trainer will use data parallel to\n'
-                'utilize the multiple GPUs to speedup your training.\n'
-                'We observed some problems with some versions of pytorch.\n'
-                'In 1.4 the performance on a NN was quite bad and accoring to\n'
-                'https://github.com/pytorch/pytorch/issues/33552\n'
-                'this was because the RNNs get no gradients.\n'
-                'In 1.5 the training got stuck, the reason is unclear in the'
-                'moment.\n'
-                'With Pytorch <= 1.3 we have not tested the code.\n'
-                f'Your pytorch version is: {torch.__version__}'
+                +
+                textwrap.indent(
+                    'devices. With this the trainer will use data parallel to\n'
+                    'utilize the multiple GPUs to speedup your training.\n'
+                    'We observed some problems with some versions of pytorch.\n'
+                    'In 1.4 the performance on a NN was quite bad and accoring to\n'
+                    'https://github.com/pytorch/pytorch/issues/33552\n'
+                    'this was because the RNNs get no gradients.\n'
+                    'In 1.5 the training got stuck, the reason is unclear in the'
+                    'moment.\n'
+                    'With Pytorch <= 1.3 we have not tested the code.\n'
+                    f'Your pytorch version is: {torch.__version__}',
+                    ' ' * len('WARNING: ')
+                )
             )
 
         # ================ MAIN TRAINING LOOP! ===================

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -335,7 +335,7 @@ class Trainer(Configurable):
                                     hook.pre_step(self)
 
                         if len(device) == 1:
-                            assert len(example) == 0, example
+                            assert len(example) == 1, (len(example), example)
                             loss, example, model_output, review = \
                                 self.train_step(self.model, example[0], device[0])
 

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -336,12 +336,14 @@ class Trainer(Configurable):
 
                         if len(device) == 1:
                             assert len(example) == 1, (len(example), example)
+                            example = example[0]
+
                             loss, example, model_output, review = \
-                                self.train_step(self.model, example[0], device[0])
+                                self.train_step(self.model, example, device[0])
 
                             with timer.pause():
                                 for hook in hooks:
-                                    hook.post_step(self, example[0], model_output, review)
+                                    hook.post_step(self, example, model_output, review)
 
                             # Release pytorch object to reduce memory footprint
                             del example

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -528,8 +528,6 @@ class Trainer(Configurable):
             # not each object is serializable with `torch.save`.
             log_path_pattern = self.log_error_state({
                 'model': self.model,
-                'example': None,
-                'model_out': None,
                 'review': review,
             })
             raise RuntimeError(
@@ -625,8 +623,6 @@ class Trainer(Configurable):
                 # not each object is serializable with `torch.save`.
                 log_path_pattern = self.log_error_state({
                     'model': self.model,
-                    # 'example': example,
-                    # 'model_out': model_out,
                     'review': summary,
                 })
                 raise RuntimeError(

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -249,8 +249,8 @@ class Trainer(Configurable):
         # Change model to train mode (e.g. activate dropout)
         self.model.train()
 
-        if isinstance(device, (tuple, list)) \
-                and all([isinstance(d, int) for d in device]):
+        if isinstance(device, (tuple, list)):
+            assert all([isinstance(d, int) for d in device]), device
             # multiple devises e.g. [0, 1], [0, 1, 2, 3], ...
             # torch.nn.parallel.DataParallel moves everything to the first gpu.
             # We do then the same thing.

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -460,6 +460,16 @@ class Trainer(Configurable):
     def optimizer_step(self):
         summary = self.clip_grad({})
 
+        # Add learning rate to the summary
+        if isinstance(self.optimizer, dict):
+            for key, optim in self.optimizer.items():
+                for i, param_group in enumerate(optim.optimizer.param_groups):
+                    summary['scalars'][f'lr/{key}/param_group_{i}'] = param_group['lr']
+        else:
+            for i, param_group in enumerate(self.optimizer.optimizer.param_groups):
+                summary['scalars'][f'lr/param_group_{i}'] = param_group['lr']
+
+        # Do the actual optimization
         if isinstance(self.optimizer, dict):
             for opti in self.optimizer.values():
                 opti.step()

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -403,10 +403,10 @@ class Trainer(Configurable):
                     # Only the summary hook will use optimizer_review
                     if optimize:
                         with self.train_timer['time_per_optimize']:
-                            optimizer_review = self.optimizer_step()
+                            optimizer_summary = self.optimizer_step()
                             for hook in hooks:
-                                hook.post_step(self, None, None, optimizer_review)
-                            del optimizer_review
+                                hook.post_optimize(self, optimizer_summary)
+                            del optimizer_summary
 
                         self.iteration += 1
 

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -866,7 +866,7 @@ class ContextTimerDict:
     >>> timer = ContextTimerDict()
     >>> with timer['test'] as t:
     ...     time.sleep(0.1)
-    ...     with t.exclude():
+    ...     with t.pause():
     ...         time.sleep(0.1)
     ...     time.sleep(0.1)
     >>> timer

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -335,13 +335,13 @@ class Trainer(Configurable):
                                     hook.pre_step(self)
 
                         if len(device) == 1:
-                            example, = example
+                            assert len(example) == 0, example
                             loss, example, model_output, review = \
-                                self.train_step(self.model, example, device[0])
+                                self.train_step(self.model, example[0], device[0])
 
                             with timer.pause():
                                 for hook in hooks:
-                                    hook.post_step(self, example, model_output, review)
+                                    hook.post_step(self, example[0], model_output, review)
 
                             # Release pytorch object to reduce memory footprint
                             del example

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -499,11 +499,8 @@ class Trainer(Configurable):
 
     def step(self, model, example, timer, device):
         # TODO: Backup OutOfMemory
-        # with self.train_timer['time_per_step']:
         with timer['time_per_to_device']:
-            example = self.model.example_to_device(
-                example, device
-            )
+            example = model.example_to_device(example, device)
         with timer['time_per_forward']:
             model_out = model(example)
         with timer['time_per_review']:

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -294,6 +294,9 @@ class Trainer(Configurable):
                 )
             )
 
+        assert self.virtual_minibatch_size % len(device) == 0, (self.virtual_minibatch_size, device)
+        assert len(device) > 0, (self.virtual_minibatch_size, device)
+
         # ================ MAIN TRAINING LOOP! ===================
         try:
             train_iterable = None

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -274,6 +274,21 @@ class Trainer(Configurable):
             hooks.append(ProgressBarHook(self._stop_trigger, max_it_len))
         hooks = sorted(hooks, key=lambda h: h.priority, reverse=True)
 
+        if len(device) >= 2:
+            print(
+                'WARNING: You called padertorch.Trainer.train with multiple\n'
+                'devices. With this the trainer will use data parallel to\n'
+                'utilize the multiple GPUs to speedup your training.\n'
+                'We observed some problems with some versions of pytorch.\n'
+                'In 1.4 the performance on a NN was quite bad and accoring to\n'
+                'https://github.com/pytorch/pytorch/issues/33552\n'
+                'this was because the RNNs get no gradients.\n'
+                'In 1.5 the training got stuck, the reason is unclear in the'
+                'moment.\n'
+                'With Pytorch <= 1.3 we have not tested the code.\n'
+                f'Your pytorch version is: {torch.__version__}'
+            )
+
         # ================ MAIN TRAINING LOOP! ===================
         try:
             train_iterable = None

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -423,7 +423,8 @@ class Trainer(Configurable):
 
             for key, value in losses.items():
                 weight = loss_weights[key] if loss_weights is not None else 1.
-                loss = loss + (weight * value)
+                if weight != 0:
+                    loss = loss + (weight * value)
                 if 'scalars' not in review:
                     review['scalars'] = {}
                 review['scalars'][f'{key}_loss_weight'] = weight

--- a/tests/test_train/test_hooks.py
+++ b/tests/test_train/test_hooks.py
@@ -99,12 +99,12 @@ def test_summary_hook():
         # with pytest.raises(KeyError, match=r"'loss'") as excinfo:
         #     hook.update_summary({})
 
-        hook.update_summary({
-            'loss': torch.tensor(1)
-        })
+        # hook.update_summary({
+        #     'loss': torch.tensor(1)
+        # })
 
         hook.update_summary({
-            'loss': torch.tensor(1),
+            # 'loss': torch.tensor(1),
             'scalars': {
                 'a': 2,
                 'b': torch.tensor(3),
@@ -112,7 +112,7 @@ def test_summary_hook():
         })
 
         hook.update_summary({
-            'loss': torch.tensor(1),
+            # 'loss': torch.tensor(1),
             'texts': {
                 'c': 'abc',
             }
@@ -160,18 +160,11 @@ def test_summary_hook():
         expect = [
             {},
             {'step': 10, 'summary': {'value': [
-                {'tag': 'training/loss', 'simple_value': 1.0}
-            ]}},
-            {'step': 10, 'summary': {'value': [
                 {'tag': 'training/a', 'simple_value': 2.0}
             ]}},
             {'step': 10, 'summary': {'value': [
                 {'tag': 'training/b', 'simple_value': 3.0}
             ]}},
-            {'step': 10,
-             'summary': {'value': [
-                 {'tag': 'training/lr/param_group_0', 'simple_value': 1.0}
-             ]}},
             {'step': 10, 'summary': {'value': [
                 {'tag': 'training/c/text_summary',
                  'tensor': {
@@ -191,7 +184,7 @@ def test_summary_hook_fail_duplicate_key():
     hook = pt.train.hooks.SummaryHook((1, 'iteration'))
 
     hook.update_summary({
-        'loss': torch.tensor(1),
+        # 'loss': torch.tensor(1),
         'scalars': {
             'a': 2,
             'b': torch.tensor(3),

--- a/tests/test_train/test_hooks.py
+++ b/tests/test_train/test_hooks.py
@@ -93,8 +93,11 @@ def test_summary_hook():
         hook = pt.train.hooks.SummaryHook(
             (1, 'iteration'),
         )
-        with pytest.raises(KeyError, match=r"'loss'") as excinfo:
-            hook.update_summary({})
+
+        # Missing key 'loss' is now allowed, because the optimizer reports now
+        # the summary directly to the hooks, instead of appending the review.
+        # with pytest.raises(KeyError, match=r"'loss'") as excinfo:
+        #     hook.update_summary({})
 
         hook.update_summary({
             'loss': torch.tensor(1)


### PR DESCRIPTION
 - Use the virtual mini batch size to distribute to different GPUs
 - Should work with most models without modification
 - Refactor the training loop to support multiple GPUs and
   - The iteration of the trainer can now be manipulated from hooks (e.g. back off)
   - The iteration indicates now the number of optimizer steps and not the number of example used
 - The step function signature changes to support different devices
 - The optimizer review is now separately reported to the hooks
 - Changed _maybe_add_loss_to_review to _review_to_loss_and_summary
 - Add log_error_state for better debugging
 - Remove Trainer.backward
 - Dropped backward in train_step
 - Add gradient check

 - rename train_iterator to train_dataset

 - [x] Support multiple GPUs to process examples from the virtual mini batch
 - [ ] Support multiple GPUs for validation