### PR TITLE
Example for modular tasnet

### DIFF
--- a/padertorch/configurable.py
+++ b/padertorch/configurable.py
@@ -669,8 +669,14 @@ def resolve_main_python_path() -> str:
     """
     python_path = getattr(sys.modules['__main__'].__spec__, 'name', '__main__')
 
-    if python_path == '__main__':
-        python_path = get_module_name_from_file(sys.modules['__main__'].__file__)
+    # In an interactive interpreter, sys.modules['__main__'] doesn't have a
+    # __file__ attribute, so just keep __main__ as python_path then. This
+    # obviously doesn't allow to load a config created in an interactive
+    # interpreter from outside.
+    if python_path == '__main__' and hasattr(
+            sys.modules['__main__'], '__file__'):
+        python_path = get_module_name_from_file(
+            sys.modules['__main__'].__file__)
 
     return python_path
 

--- a/padertorch/contrib/examples/tasnet/tas_coders.py
+++ b/padertorch/contrib/examples/tasnet/tas_coders.py
@@ -172,21 +172,21 @@ class StftEncoder(torch.nn.Module):
             fading=False, complex_representation='concat'
         )
 
-    def forward(self, inputs, num_samples=None):
+    def forward(self, inputs, sequence_lengths: torch.Tensor = None
+    ) -> Tuple[torch.Tensor, Union[torch.Tensor, None]]:
         """
         Args:
             inputs: shape: [..., T], T is #samples
-            num_samples: list or tensor of #samples
+            sequence_lengths: list or tensor of #samples
         Returns:
             [..., N, frames] the stft encoded signal
         """
 
         encoded = self.stft(inputs)
         encoded = rearrange(encoded, '... frames fbins -> ... fbins frames')
-        if num_samples is not None:
-
+        if sequence_lengths is not None:
             num_frames = torch.tensor([self.stft.samples_to_frames(samples)
-                                       for samples in num_samples])
+                                       for samples in sequence_lengths])
             return encoded, num_frames
         else:
             return encoded
@@ -226,7 +226,7 @@ class IstftDecoder(torch.nn.Module):
             shift=stride, fading=False, complex_representation='concat'
         )
 
-    def forward(self, stft_signal):
+    def forward(self, stft_signal) -> torch.Tensor:
         """
         Args:
             stft_signal: shape: [B, ..., N, Frames]

--- a/padertorch/contrib/examples/tasnet/tas_coders.py
+++ b/padertorch/contrib/examples/tasnet/tas_coders.py
@@ -162,15 +162,21 @@ class StftEncoder(torch.nn.Module):
         self.stride = stride
 
         if stride is None:
-            stride = L // 2
-        self.stft = STFT(size=N-2, shift=stride, window_length=L, fading=False,
-                         complex_representation='concat')
+            stride = window_length // 2
+
+        # feature_size - 2 because the stft adds two uninformative
+        # values for an even size.
+        # Note that the STFT does not support uneven sizes at the moment.
+        self.stft = STFT(
+            size=feature_size - 2, shift=stride, window_length=window_length,
+            fading=False, complex_representation='concat'
+        )
 
     def forward(self, inputs, num_samples=None):
         """
         Args:
             inputs: shape: [..., T], T is #samples
-            num_samples, list or tensor of #samples
+            num_samples: list or tensor of #samples
         Returns:
             [..., N, frames] the stft encoded signal
         """
@@ -208,16 +214,22 @@ class IstftDecoder(torch.nn.Module):
         self.window_length = window_length
         self.feature_size = feature_size
         self.stride = stride
+
         if stride is None:
-            stride = L // 2
-        self.stft = STFT(size=N-2, shift=stride, window_length=L, fading=False,
-                         complex_representation='concat')
+            stride = window_length // 2
+
+        # feature_size - 2 because the stft adds two uninformative
+        # values for an even size.
+        # Note that the STFT does not support uneven sizes at the moment.
+        self.stft = STFT(
+            size=feature_size - 2, window_length=window_length,
+            shift=stride, fading=False, complex_representation='concat'
+        )
 
     def forward(self, stft_signal):
         """
         Args:
             stft_signal: shape: [B, ..., N, Frames]
-            num_samples, list or tensor of #samples
         Returns:
             [B, ..., T]
         """

--- a/padertorch/contrib/examples/tasnet/tasnet.py
+++ b/padertorch/contrib/examples/tasnet/tasnet.py
@@ -12,80 +12,50 @@ from padertorch.ops.losses.regression import si_sdr_loss, log_mse_loss
 from padertorch.ops.mappings import ACTIVATION_FN_MAP
 
 
-class TasNet(pt.Model):
+class ModularTasNet(pt.Model):
     def __init__(
             self,
-            hidden_size: int = 64,
-            encoder_block_size: int = 16,
-            rnn_size: int = 128,
-            dprnn_window_length: Union[int, str] = 100,
-            dprnn_hop_size: Union[str, int] = 50,
+            encoder,
+            separator,
+            decoder,
             mask: bool = True,
-            dprnn_layers: int = 6,
             output_nonlinearity: Optional[str] = 'sigmoid',
-            inter_chunk_type: str = 'blstm',
-            intra_chunk_type: str = 'blstm',
             num_speakers: int = 2,
             additional_out_size: int = 0,
             sample_rate=8000,
     ):
         """
         Args:
-            hidden_size: Size between the layers (N)
-            encoder_block_size:
-            rnn_size: Size of the NNs in the inter- or intra-chunk RNNs. This
-                corresponds to H or H//2.
-            dprnn_window_length: Window length of the DPRNN segmentation (K).
-                If set to 'auto', it is determined for each example
-                independently based on the input length and the "rule of thumb"
-                K \approx sqrt(2L)
-            dprnn_hop_size: Hop size of the DPRNN segmentation (P). If set to
-                'auto' it is set to 50% of the block length K (half overlap).
+            encoder:
+            separator:
+            decoder:
             mask: If `True`, use the output of the NN as a mask in tas domain
                 for separation. Otherwise, use the output directly as an
                 estimation for the separated signals.
-            dprnn_layers: Number of stacked DPRNN blocks
             output_nonlinearity: Nonlinearity applied to the output (right
                 before masking/decoding)
-            inter_chunk_type: Type of the inter-chunk RNN
-            intra_chunk_type: Type of the intra-chunk RNN
             num_speakers: The number of speakers/output streams
             additional_out_size: Size of the additional output. Has no effect if
                 set to 0.
-            input_norm: If `True` normalize the input
         """
         super().__init__()
 
         self.mask = mask
         self.additional_out_size = additional_out_size
-
+        hidden_size = separator.feat_size
         self.input_proj = torch.nn.Conv1d(hidden_size, hidden_size, 1)
         self.output_prelu = torch.nn.PReLU()
         self.output_proj = torch.nn.Conv1d(
             hidden_size, hidden_size * num_speakers + additional_out_size, 1
         )
 
-        self.encoder = TasEncoder(
-            L=encoder_block_size,
-            N=hidden_size,
-        )
+        self.encoder = encoder
 
         self.encoded_input_norm = torch.nn.LayerNorm(hidden_size)
 
-        self.dprnn = DPRNN(
-            feat_size=hidden_size,
-            rnn_size=rnn_size,
-            window_length=dprnn_window_length,
-            hop_size=dprnn_hop_size,
-            inter_chunk_type=inter_chunk_type,
-            intra_chunk_type=intra_chunk_type,
-            num_blocks=dprnn_layers,
-        )
+        self.dprnn = separator
 
-        self.decoder = TasDecoder(
-            L=encoder_block_size,
-            N=hidden_size
-        )
+        self.decoder = decoder
 
         self.output_nonlinearity = ACTIVATION_FN_MAP[output_nonlinearity]()
 
@@ -228,52 +198,67 @@ class TasNet(pt.Model):
         self.dprnn.flatten_parameters()
 
 
-class ModularTasNet(TasNet):
+class TasNet(ModularTasNet):
     def __init__(
             self,
-            encoder,
-            separator,
-            decoder,
+            hidden_size: int = 64,
+            encoder_block_size: int = 16,
+            rnn_size: int = 128,
+            dprnn_window_length: Union[int, str] = 100,
+            dprnn_hop_size: Union[str, int] = 50,
             mask: bool = True,
+            dprnn_layers: int = 6,
             output_nonlinearity: Optional[str] = 'sigmoid',
+            inter_chunk_type: str = 'blstm',
+            intra_chunk_type: str = 'blstm',
             num_speakers: int = 2,
             additional_out_size: int = 0,
             sample_rate=8000,
     ):
         """
         Args:
-            encoder:
-            separator:
-            decoder:
+            hidden_size: Size between the layers (N)
+            encoder_block_size:
+            rnn_size: Size of the NNs in the inter- or intra-chunk RNNs. This
+                corresponds to H or H//2.
+            dprnn_window_length: Window length of the DPRNN segmentation (K).
+                If set to 'auto', it is determined for each example
+                independently based on the input length and the "rule of thumb"
+                K \approx sqrt(2L)
+            dprnn_hop_size: Hop size of the DPRNN segmentation (P). If set to
+                'auto' it is set to 50% of the block length K (half overlap).
             mask: If `True`, use the output of the NN as a mask in tas domain
                 for separation. Otherwise, use the output directly as an
                 estimation for the separated signals.
+            dprnn_layers: Number of stacked DPRNN blocks
             output_nonlinearity: Nonlinearity applied to the output (right
                 before masking/decoding)
+            inter_chunk_type: Type of the inter-chunk RNN
+            intra_chunk_type: Type of the intra-chunk RNN
             num_speakers: The number of speakers/output streams
-            additional_out_size: Size of the additional output. Has no effect if
-                set to 0.
+            additional_out_size: Size of the additional output. Has no effect
+             if set to 0.
         """
-        super().__init__()
-
-        self.mask = mask
-        self.additional_out_size = additional_out_size
-        hidden_size = separator.feat_size
-        self.input_proj = torch.nn.Conv1d(hidden_size, hidden_size, 1)
-        self.output_prelu = torch.nn.PReLU()
-        self.output_proj = torch.nn.Conv1d(
-            hidden_size, hidden_size * num_speakers + additional_out_size, 1
+        encoder = TasEncoder(
+            window_length=encoder_block_size,
+            feature_size=hidden_size,
         )
 
-        self.encoder = encoder
+        separator = DPRNN(
+            feat_size=hidden_size,
+            rnn_size=rnn_size,
+            window_length=dprnn_window_length,
+            hop_size=dprnn_hop_size,
+            inter_chunk_type=inter_chunk_type,
+            intra_chunk_type=intra_chunk_type,
+            num_blocks=dprnn_layers,
+        )
 
-        self.encoded_input_norm = torch.nn.LayerNorm(hidden_size)
-
-        self.dprnn = separator
-
-        self.decoder = decoder
-
-        self.output_nonlinearity = ACTIVATION_FN_MAP[output_nonlinearity]()
-
-        self.num_speakers = num_speakers
-        self.sample_rate = sample_rate
+        decoder = TasDecoder(
+            window_length=encoder_block_size,
+            feature_size=hidden_size
+        )
+        super().__init__(
+            encoder, separator, decoder, mask, output_nonlinearity,
+            num_speakers, additional_out_size, sample_rate,
+        )

--- a/padertorch/contrib/examples/tasnet/train_modular.py
+++ b/padertorch/contrib/examples/tasnet/train_modular.py
@@ -1,0 +1,356 @@
+"""
+Example call on NT infrastructure:
+
+export STORAGE=<your desired storage root>
+mkdir -p $STORAGE/pth_models/dprnn
+python -m padertorch.contrib.examples.tasnet.train print_config
+python -m padertorch.contrib.examples.tasnet.train
+"""
+import torch
+from paderbox.io import load_audio
+
+from sacred import Experiment
+import sacred.commands
+
+# sacred.SETTINGS.CONFIG.READ_ONLY_CONFIG = False
+
+import os
+from pathlib import Path
+
+from sacred.utils import InvalidConfigError, MissingConfigError
+
+import padertorch as pt
+import padertorch.contrib.examples.tasnet.tasnet
+import paderbox as pb
+import numpy as np
+
+from sacred.observers.file_storage import FileStorageObserver
+from lazy_dataset.database import JsonDatabase
+
+from padertorch.contrib.neumann.chunking import RandomChunkSingle
+from padertorch.contrib.ldrude.utils import get_new_folder
+
+nickname = "dprnn"
+ex = Experiment(nickname)
+
+
+def get_storage_dir():
+    # Sacred should not add path_template to the config
+    # -> move this few lines to a function
+    path_template = Path(os.environ["STORAGE"]) / 'pth_models' / nickname
+    path_template.mkdir(exist_ok=True, parents=True)
+    return get_new_folder(path_template, mkdir=False)
+
+
+@ex.config
+def config():
+    debug = False
+    batch_size = 4  # Runs on 4GB GPU mem. Can safely be set to 12 on 12 GB (e.g., GTX1080)
+    chunk_size = 32000  # 4s chunks @8kHz
+
+    train_dataset = "mix_2_spk_min_tr"
+    validate_dataset = "mix_2_spk_min_cv"
+    target = 'speech_source'
+    lr_scheduler_step = 2
+    lr_scheduler_gamma = 0.98
+    load_model_from = None
+    database_json = None
+
+    if database_json is None:
+        raise MissingConfigError(
+            'You have to set the path to the database JSON!', 'database_json')
+    if not Path(database_json).exists():
+        raise InvalidConfigError('The database JSON does not exist!',
+                                 'database_json')
+
+    # Start with an empty dict to allow tracking by Sacred
+    feat_size = 64
+    encoder_window_size = 16
+    trainer = {
+        "model": {
+            "factory": pt.contrib.examples.tasnet.tasnet.ModularTasNet,
+            'encoder': {
+                'factory': pt.contrib.examples.tasnet.tas_coders.TasEncoder,
+                'L': encoder_window_size,
+                'N': feat_size,
+            },
+            'separator': {
+                'factory': pt.modules.dual_path_rnn.DPRNN,
+                'feat_size': 64,
+                'rnn_size': 128,
+                'window_length': 100,
+                'hop_size': 50,
+                'num_blocks': 6,
+            },
+            'decoder': {
+                'factory': pt.contrib.examples.tasnet.tas_coders.TasDecoder,
+                'L': encoder_window_size,
+                'N': feat_size,
+            },
+        },
+        "storage_dir": None,
+        "optimizer": {
+            "factory": pt.optimizer.Adam,
+            "gradient_clipping": 1
+        },
+        "summary_trigger": (1000, "iteration"),
+        "stop_trigger": (100_000, "iteration"),
+        "loss_weights": {
+            "si-sdr": 1.0,
+            "log-mse": 0.0,
+            "si-sdr-grad-stop": 0.0,
+        }
+    }
+    pt.Trainer.get_config(trainer)
+    if trainer['storage_dir'] is None:
+        trainer['storage_dir'] = get_storage_dir()
+
+    ex.observers.append(FileStorageObserver(
+        Path(trainer['storage_dir']) / 'sacred')
+    )
+
+
+@ex.named_config
+def win2():
+    """
+    This is the configuration for the best performing model from the DPRNN
+    paper. Training takes very long time with this configuration.
+    """
+    # The model becomes very memory consuming with this small window size.
+    # You might have to reduce the chunk size as well.
+    batch_size = 1
+
+    trainer = {
+        'model': {
+            'encoder': {
+                'L': 2
+            },
+            'separator': {
+                'window_length': 250,
+                'dprnn_hop_size': 125,  # Half of window length
+            }
+        }
+    }
+
+@ex.named_config
+def stft():
+    trainer = {
+        'model': {
+            'encoder': {
+                'factory': 'padertorch.contrib.examples.tasnet.tas_coders.StftEncoder'
+            },
+            'decoder': {
+                'factory': 'padertorch.contrib.examples.tasnet.tas_coders.IstftDecoder'
+            },
+        }
+    }
+
+
+@ex.named_config
+def log_mse():
+    trainer = {
+        'loss_weights': {
+            'si-sdr': 0.0,
+            'log-mse': 1.0,
+        }
+    }
+
+
+@ex.named_config
+def on_wsj0_2mix_max():
+    chunk_size = -1
+    train_dataset = "mix_2_spk_max_tr"
+    validate_dataset = "mix_2_spk_max_cv"
+
+
+@ex.capture
+def pre_batch_transform(inputs):
+    return {
+        's': np.ascontiguousarray([
+            load_audio(p)
+            for p in inputs['audio_path']['speech_source']
+        ], np.float32),
+        'y': np.ascontiguousarray(
+            load_audio(inputs['audio_path']['observation']), np.float32),
+        'num_samples': inputs['num_samples'],
+        'example_id': inputs['example_id'],
+        'audio_path': inputs['audio_path'],
+    }
+
+
+def prepare_iterable(
+        db, dataset: str, batch_size, chunk_size, prefetch=True,
+        iterator_slice=None
+):
+    """
+    This is re-used in the evaluate script
+    """
+    iterator = db.get_dataset(dataset)
+
+    if iterator_slice is not None:
+        iterator = iterator[iterator_slice]
+
+    iterator = (
+        iterator
+            .map(pre_batch_transform)
+            .map(RandomChunkSingle(chunk_size, chunk_keys=('y', 's'), axis=-1))
+            .shuffle(reshuffle=True)
+            .batch(batch_size)
+            .map(lambda batch: sorted(
+            batch,
+            key=lambda example: example['num_samples'],
+            reverse=True,
+        ))
+            .map(pt.data.utils.collate_fn)
+    )
+
+    if prefetch:
+        iterator = iterator.prefetch(8, 16, catch_filter_exception=True)
+    elif chunk_size > 0:
+        iterator = iterator.catch()
+
+    return iterator
+
+
+@ex.capture
+def prepare_iterable_captured(
+        database_obj, dataset, batch_size, debug, chunk_size,
+        iterator_slice=None,
+):
+    if iterator_slice is None:
+        if debug:
+            iterator_slice = slice(0, 100, 1)
+
+    return prepare_iterable(
+        database_obj, dataset, batch_size, chunk_size,
+        prefetch=not debug,
+        iterator_slice=iterator_slice,
+    )
+
+
+@ex.capture
+def dump_config_and_makefile(_config):
+    """
+    Dumps the configuration into the experiment dir and creates a Makefile
+    next to it. If a Makefile already exists, it does not do anything.
+    """
+    experiment_dir = Path(_config['trainer']['storage_dir'])
+    makefile_path = Path(experiment_dir) / "Makefile"
+
+    if not makefile_path.exists():
+        config_path = experiment_dir / "config.json"
+
+        pb.io.dump_json(_config, config_path)
+
+        main_python_path = pt.configurable.resolve_main_python_path()
+        eval_python_path = '.'.join(
+            pt.configurable.resolve_main_python_path().split('.')[:-1]
+        ) + '.evaluate'
+        makefile_path.write_text(
+            f"SHELL := /bin/bash\n"
+            f"MODEL_PATH := $(shell pwd)\n"
+            f"\n"
+            f"export OMP_NUM_THREADS=1\n"
+            f"export MKL_NUM_THREADS=1\n"
+            f"\n"
+            f"train:\n"
+            f"\tpython -m {main_python_path} with config.json\n"
+            f"\n"
+            f"ccsalloc:\n"
+            f"\tccsalloc \\\n"
+            f"\t\t--notifyuser=awe \\\n"
+            f"\t\t--res=rset=1:ncpus=4:gtx1080=1:ompthreads=1 \\\n"
+            f"\t\t--time=100h \\\n"
+            f"\t\t--join \\\n"
+            f"\t\t--stdout=stdout \\\n"
+            f"\t\t--tracefile=%x.%reqid.trace \\\n"
+            f"\t\t-N train_{nickname} \\\n"
+            f"\t\tpython -m {main_python_path} with config.json\n"
+            f"\n"
+            f"evaluate:\n"
+            f"\tpython -m {eval_python_path} init with model_path=$(MODEL_PATH)\n"
+        )
+
+
+@ex.command(unobserved=True)
+def init(_config, _run):
+    """Create a storage dir, write Makefile. Do not start any training."""
+    sacred.commands.print_config(_run)
+    dump_config_and_makefile()
+
+    print()
+    print('Initialized storage dir. Now run these commands:')
+    print(f"cd {_config['trainer']['storage_dir']}")
+    print(f"make train")
+    print()
+    print('or')
+    print()
+    print(f"cd {_config['trainer']['storage_dir']}")
+    print('make ccsalloc')
+
+
+@ex.capture
+def prepare_and_train(_run, _log, trainer, train_dataset, validate_dataset,
+                      lr_scheduler_step, lr_scheduler_gamma,
+                      load_model_from, database_json):
+    trainer = pt.Trainer.from_config(trainer)
+    checkpoint_path = trainer.checkpoint_dir / 'ckpt_latest.pth'
+
+    if load_model_from is not None and not checkpoint_path.is_file():
+        _log.info(f'Loading model weights from {load_model_from}')
+        checkpoint = torch.load(load_model_from)
+        trainer.model.load_state_dict(checkpoint['model'])
+
+    db = JsonDatabase(database_json)
+
+    # Perform a test run to check if everything works
+    trainer.test_run(
+        prepare_iterable_captured(db, train_dataset),
+        prepare_iterable_captured(db, validate_dataset),
+    )
+
+    # Register hooks and start the actual training
+
+    # Learning rate scheduler
+    if lr_scheduler_step:
+        trainer.register_hook(pt.train.hooks.LRSchedulerHook(
+            torch.optim.lr_scheduler.StepLR(
+                trainer.optimizer.optimizer,
+                step_size=lr_scheduler_step,
+                gamma=lr_scheduler_gamma,
+            )
+        ))
+
+        # Don't use LR back-off
+        trainer.register_validation_hook(
+            prepare_iterable_captured(db, validate_dataset),
+        )
+    else:
+        # Use LR back-off
+        trainer.register_validation_hook(
+            prepare_iterable_captured(db, validate_dataset),
+            n_back_off=5, back_off_patience=3
+        )
+
+    trainer.train(
+        prepare_iterable_captured(db, train_dataset),
+        resume=checkpoint_path.is_file()
+    )
+
+
+@ex.main
+def main(_config, _run):
+    """Main does resume directly.
+
+    It also writes the `Makefile` and `config.json` again, even when you are
+    resuming from an initialized storage dir. This way, the `config.json` is
+    always up to date. Historic configuration can be found in Sacred's folder.
+    """
+    sacred.commands.print_config(_run)
+    dump_config_and_makefile()
+    prepare_and_train()
+
+
+if __name__ == '__main__':
+    with pb.utils.debug_utils.debug_on(Exception):
+        ex.run_commandline()

--- a/padertorch/contrib/examples/tasnet/train_modular.py
+++ b/padertorch/contrib/examples/tasnet/train_modular.py
@@ -71,7 +71,7 @@ def config():
             "factory": pt.contrib.examples.tasnet.tasnet.ModularTasNet,
             'encoder': {
                 'factory': pt.contrib.examples.tasnet.tas_coders.TasEncoder,
-                'window_size': encoder_window_size,
+                'window_length': encoder_window_size,
                 'feature_size': feat_size,
             },
             'separator': {
@@ -84,7 +84,7 @@ def config():
             },
             'decoder': {
                 'factory': pt.contrib.examples.tasnet.tas_coders.TasDecoder,
-                'window_size': encoder_window_size,
+                'window_length': encoder_window_size,
                 'feature_size': feat_size,
             },
         },
@@ -123,7 +123,7 @@ def win2():
     trainer = {
         'model': {
             'encoder': {
-                'window_size': 2
+                'window_length': 2
             },
             'separator': {
                 'window_length': 250,

--- a/padertorch/contrib/examples/tasnet/train_modular.py
+++ b/padertorch/contrib/examples/tasnet/train_modular.py
@@ -30,7 +30,7 @@ from lazy_dataset.database import JsonDatabase
 from padertorch.contrib.neumann.chunking import RandomChunkSingle
 from padertorch.contrib.ldrude.utils import get_new_folder
 
-nickname = "dprnn"
+nickname = "tasnet"
 ex = Experiment(nickname)
 
 
@@ -71,8 +71,8 @@ def config():
             "factory": pt.contrib.examples.tasnet.tasnet.ModularTasNet,
             'encoder': {
                 'factory': pt.contrib.examples.tasnet.tas_coders.TasEncoder,
-                'L': encoder_window_size,
-                'N': feat_size,
+                'window_size': encoder_window_size,
+                'feature_size': feat_size,
             },
             'separator': {
                 'factory': pt.modules.dual_path_rnn.DPRNN,
@@ -84,8 +84,8 @@ def config():
             },
             'decoder': {
                 'factory': pt.contrib.examples.tasnet.tas_coders.TasDecoder,
-                'L': encoder_window_size,
-                'N': feat_size,
+                'window_size': encoder_window_size,
+                'feature_size': feat_size,
             },
         },
         "storage_dir": None,
@@ -123,7 +123,7 @@ def win2():
     trainer = {
         'model': {
             'encoder': {
-                'L': 2
+                'window_size': 2
             },
             'separator': {
                 'window_length': 250,

--- a/padertorch/contrib/je/hooks/swa.py
+++ b/padertorch/contrib/je/hooks/swa.py
@@ -45,7 +45,7 @@ class SWAHook(TriggeredHook):
             else:
                 r = 1 / self.count
                 self.swa_module = nested_op(
-                    lambda x, y: (1-r) * x + r * y,
+                    lambda x, y: (1-r) * x.to(y.device) + r * y,
                     self.swa_module,
                     module.state_dict()
                 )

--- a/padertorch/contrib/je/modules/conv.py
+++ b/padertorch/contrib/je/modules/conv.py
@@ -21,7 +21,6 @@ def to_pair(x):
 class Pad(Module):
     """
     Adds padding of a certain size either to front, end or both.
-    ToDo: Exception if side is None but size != 0 (requires adjustments in _Conv)
     """
     def __init__(self, side='both', mode='constant'):
         super().__init__()
@@ -29,22 +28,33 @@ class Pad(Module):
         self.mode = mode
 
     def forward(self, x, size):
+        """
+
+        Args:
+            x: input tensor of shape b,c,(f,)t
+            size: size to pad to dims (f,)t
+
+        Returns:
+
+        """
         sides = to_list(self.side, x.dim() - 2)
         sizes = to_list(size, x.dim() - 2)
         pad = []
         for side, size in list(zip(sides, sizes))[::-1]:
             if side is None or size < 1:
+                assert size == 0, sizes
                 pad.extend([0, 0])
             elif side == 'front':
                 pad.extend([size, 0])
             elif side == 'both':
+                # if size is odd: end is padded more than front
                 pad.extend([size // 2, math.ceil(size / 2)])
             elif side == 'end':
                 pad.extend([0, size])
             else:
                 raise ValueError(f'pad side {side} unknown')
 
-        x = F.pad(x, tuple(pad), mode=self.mode)
+        x = F.pad(x, pad, mode=self.mode)
         return x
 
 
@@ -52,23 +62,33 @@ class Trim(Module):
     """
     Removes a certain number of values either from front, end or both.
     (Counter part to Pad)
-    ToDo: Exception if side is None but size != 0 (requires adjustments in _Conv)
     """
     def __init__(self, side='both'):
         super().__init__()
         self.side = side
 
     def forward(self, x, size):
+        """
+
+        Args:
+            x: input tensor of shape b,c,(f,)t
+            size: size to trim at dims (f,)t
+
+        Returns:
+
+        """
         sides = to_list(self.side, x.dim() - 2)
         sizes = to_list(size, x.dim() - 2)
         slc = [slice(None)] * x.dim()
         for i, (side, size) in enumerate(zip(sides, sizes)):
             idx = 2 + i
             if side is None or size < 1:
+                assert size == 0, sizes
                 continue
             elif side == 'front':
                 slc[idx] = slice(size, x.shape[idx])
             elif side == 'both':
+                # if size is odd: end is trimmed more than front
                 slc[idx] = slice(size//2, -math.ceil(size / 2))
             elif side == 'end':
                 slc[idx] = slice(0, -size)
@@ -81,8 +101,9 @@ class Trim(Module):
 class _Conv(Module):
     """
     Wrapper for torch.nn.ConvXd and torch.nn.ConvTransoseXd for X in {1,2}
-    including additional options of applying an (gated) activation or
-    normalizing the network output. Base Class for Conv(Transpose)Xd.
+    including additional options of applying a (gated) activation or
+    normalizing the network output (or input if pre_activation).
+    Base Class for Conv(Transpose)Xd.
     """
     conv_cls = None
 
@@ -185,9 +206,21 @@ class _Conv(Module):
                 torch.nn.init.zeros_(self.gate_conv.bias)
 
     def forward(
-            self, x, seq_len=None, out_shape=None, out_lengths=None,
+            self, x, seq_len=None, out_shape=None, seq_len_out=None,
             norm_kwargs={}
     ):
+        """
+
+        Args:
+            x: input tensor of shape b,c,(f,)t
+            seq_len: input sequence lengths for each sequence in the mini-batch
+            out_shape: desired output shape relevant for transposed convs
+            seq_len_out: desired output sequence lengths relevant for transposed convs
+            norm_kwargs:
+
+        Returns:
+
+        """
         if self.training and self.dropout > 0.:
             x = F.dropout(x, self.dropout)
 
@@ -200,10 +233,10 @@ class _Conv(Module):
             x = self.pad_or_trim(x)
 
         y = self.conv(x)
-        if out_lengths is not None:
-            seq_len = out_lengths
+        if seq_len_out is not None:
+            seq_len = seq_len_out
         elif seq_len is not None:
-            seq_len = self.get_out_lengths(seq_len)
+            seq_len = self.get_seq_len_out(seq_len)
 
         if not self.pre_activation:
             if self.norm is not None:
@@ -213,48 +246,78 @@ class _Conv(Module):
             g = self.gate_conv(x)
             y = y * torch.sigmoid(g)
 
-        if self.is_transpose():
+        if out_shape is not None:
             y = self.trim_padded_or_pad_trimmed(y, out_shape)
         return y, seq_len
 
     def pad_or_trim(self, x):
+        """
+        Either adds padding or trims parts of the signal not being processed (due to striding).
+        Args:
+            x: input tensor of shape b,c,(f,)t
+
+        Returns:
+
+        """
         assert not self.is_transpose()
-        pad_dims = [side is not None for side in to_list(self.pad_side)]
+        pad_dims = np.array([side is not None for side in to_list(self.pad_side)])
         if any(pad_dims):
-            size = (
-                np.array(self.dilation) * (np.array(self.kernel_size) - 1)
-                - ((np.array(x.shape[2:]) - 1) % np.array(self.stride))
-            ).tolist()
-            x = Pad(side=self.pad_side)(x, size=size)
+            max_pad_size = np.array(self.dilation) * (np.array(self.kernel_size) - 1)
+            # prevent excessive padding, e.g., padding at the front while
+            # striding results in the end of the signal not being processed.
+            excess_pad_size = (np.array(x.shape[2:]) - 1) % np.array(self.stride)
+            pad_size = max_pad_size - excess_pad_size
+            pad_size *= pad_dims
+            x = Pad(side=self.pad_side)(x, size=pad_size.tolist())
         if not all(pad_dims):
-            size = (
+            # for those axis not being padded: trim size (at both sides) which is not going to be processed anyway
+            trim_size = (
                 (np.array(x.shape[2:]) - np.array(self.kernel_size))
                 % np.array(self.stride)
-            ).tolist()
-            x = Trim(side=('both' if not pad_dim else None for pad_dim in pad_dims))(x, size)
+            )
+            trim_size *= (1 - pad_dims)
+            x = Trim(side='both')(x, trim_size.tolist())
         return x
 
-    def trim_padded_or_pad_trimmed(self, y, out_shape=None):
+    def trim_padded_or_pad_trimmed(self, x, out_shape=None):
+        """
+        counter part to pad_or_trim used in transposed convolutions.
+        Only implemented if out_shape is not None!
+        Args:
+            x: input tensor of shape b,c,(f,)t
+            out_shape: target output shape
+
+        Returns:
+
+        """
         assert self.is_transpose()
         if out_shape is not None:
-            assert y.shape[:2] == tuple(out_shape)[:2], (y.shape, out_shape)
-            size = np.array(y.shape[2:]) - np.array(out_shape[2:])
+            # assert matching batch and channels dims
+            assert x.shape[:2] == tuple(out_shape)[:2], (x.shape, out_shape)
             pad_side = [
                 'both' if side is None else side  # if no padding has been used both sides have been trimmed
                 for side in to_list(self.pad_side)
             ]
+            size = np.array(x.shape[2:]) - np.array(out_shape[2:])
             if any(size > 0):
-                y = Trim(side=pad_side)(y, size=size)
+                x = Trim(side=pad_side)(x, size=size*(size > 0))
             if any(size < 0):
-                y = Pad(side=pad_side, mode='constant')(y, size=-size)
+                x = Pad(side=pad_side, mode='constant')(x, size=-size*(size < 0))
         elif any([side is not None for side in to_list(self.pad_side)]):
-            # # trim the minimal padding that could have occurred
-            # trim_size = np.array(self.dilation) * (np.array(self.kernel_size) - 1) - (np.array(self.stride)-1)
-            # y = Trim(side=self.pad_side)(y, size=trim_size)
+            # pad_size can not be inferred
             raise NotImplementedError
-        return y
+        return x
 
     def get_out_shape(self, in_shape):
+        """
+        compute output shape given input shape
+
+        Args:
+            in_shape: input shape
+
+        Returns:
+
+        """
         out_shape = np.array(in_shape)
         assert len(out_shape) == 3 + self.is_2d(), (
             len(out_shape), self.is_2d()
@@ -276,25 +339,31 @@ class _Conv(Module):
             out_shape[2:] = np.ceil(out_shape[2:]/np.array(self.stride))
         return out_shape.astype(np.int64)
 
-    def get_out_lengths(self, in_lengths):
+    def get_seq_len_out(self, seq_len_in):
         """
+        Compute output sequence lengths for each sequence in the mini-batch
+
         L_{out} = (L_{in} - 1) \times \text{stride} - 2 \times \text{padding}
                     + \text{kernel\_size} + \text{output\_padding}
+
+        Args:
+            seq_len_in: array/list of sequence lengths
+
         Returns:
 
         """
-        out_lengths = np.array(in_lengths)
-        assert out_lengths.ndim == 1, out_lengths.ndim
+        seq_len_out = np.array(seq_len_in)
+        assert seq_len_out.ndim == 1, seq_len_out.ndim
         if self.is_transpose():
             raise NotImplementedError
         else:
             if to_list(self.pad_side)[-1] is None:
-                out_lengths = out_lengths - (
+                seq_len_out = seq_len_out - (
                     to_list(self.dilation)[-1]
                     * (to_list(self.kernel_size)[-1] - 1)
                 )
-            out_lengths = np.ceil(out_lengths/to_list(self.stride)[-1])
-        return out_lengths.astype(np.int64)
+            seq_len_out = np.ceil(seq_len_out/to_list(self.stride)[-1])
+        return seq_len_out.astype(np.int64)
 
 
 class Conv1d(_Conv):
@@ -512,17 +581,12 @@ class _CNN(Module):
                 self.norm[-1] = None
 
         convs = list()
-        residual_channels = [in_channels] + copy(out_channels)
-        layer_in_channels = copy(residual_channels)
+        layer_in_channels = [in_channels] + copy(out_channels)
         for i in range(num_layers):
             if self.dense_connections[i] is not None:
                 for dst_idx in self.dense_connections[i]:
                     assert dst_idx > i, (i, dst_idx)
-                    if self.is_transpose():
-                        layer_in_channels[i] -= self.out_channels[dst_idx - 1]
-                    else:
-                        residual_channels[dst_idx] += residual_channels[i]
-                        layer_in_channels[dst_idx] += residual_channels[i]
+                    layer_in_channels[dst_idx] += layer_in_channels[i]
             convs.append(self.conv_cls(
                 in_channels=layer_in_channels[i],
                 out_channels=self.out_channels[i],
@@ -543,15 +607,13 @@ class _CNN(Module):
         for source_idx, destination_indices in enumerate(self.residual_connections):
             if destination_indices is None:
                 continue
-            assert len(set(destination_indices)) == len(destination_indices), (
-                destination_indices
-            )
+            assert len(set(destination_indices)) == len(destination_indices), destination_indices
             for dst_idx in destination_indices:
                 assert dst_idx > source_idx, (source_idx, dst_idx)
-                if residual_channels[dst_idx] != residual_channels[source_idx]:
+                if layer_in_channels[dst_idx] != layer_in_channels[source_idx]:
                     residual_convs[f'{source_idx}->{dst_idx}'] = self.conv_cls(
-                        in_channels=residual_channels[source_idx],
-                        out_channels=residual_channels[dst_idx],
+                        in_channels=layer_in_channels[source_idx],
+                        out_channels=layer_in_channels[dst_idx],
                         kernel_size=1,
                         dropout=dropout,
                         dilation=1,
@@ -563,21 +625,34 @@ class _CNN(Module):
                         gated=False,
                     )
         self.residual_convs = nn.ModuleDict(residual_convs)
-        self.residual_channels = residual_channels
         self.layer_in_channels = layer_in_channels
 
     def forward(
-            self, x, seq_len=None, shapes=None, seq_lens=None, pool_indices=None,
+            self, x, seq_len=None,
+            out_shapes=None, seq_lens_out=None, pool_indices=None,
             norm_kwargs={}
     ):
+        """
+
+        Args:
+            x:
+            seq_len:
+            out_shapes:
+            seq_lens_out:
+            pool_indices:
+            norm_kwargs:
+
+        Returns:
+
+        """
         assert x.dim() == (3 + self.is_2d()), (x.shape, self.is_2d())
         if not self.is_transpose():
-            assert shapes is None, shapes
-            assert seq_lens is None, seq_lens
+            assert out_shapes is None, out_shapes
+            assert seq_lens_out is None, seq_lens_out
             assert pool_indices is None, pool_indices.shape
-        out_shapes = to_list(copy(shapes), self.num_layers+1)[::-1][1:]
-        out_lengths = to_list(copy(seq_lens), self.num_layers+1)[::-1][1:]
-        pool_indices = to_list(copy(pool_indices), self.num_layers)[::-1]
+        out_shapes = to_list(copy(out_shapes), self.num_layers)
+        seq_lens_out = to_list(copy(seq_lens_out), self.num_layers)
+        pool_indices = to_list(copy(pool_indices), self.num_layers)
         residual_skip_signals = defaultdict(list)
         dense_skip_signals = defaultdict(list)
         for i, conv in enumerate(self.convs):
@@ -592,30 +667,17 @@ class _CNN(Module):
                 for dst_idx in self.residual_connections[i]:
                     residual_skip_signals[dst_idx].append((i, x))
             if self.dense_connections[i] is not None:
+                assert not self.is_transpose()
                 for dst_idx in sorted(self.dense_connections[i]):
-                    if self.is_transpose():
-                        x, x_skip = torch.split(
-                            x,
-                            [
-                                self.layer_in_channels[i],
-                                self.out_channels[dst_idx - 1]
-                            ],
-                            dim=1
-                        )
-                        dense_skip_signals[dst_idx].append((i, x_skip))
-                    else:
-                        dense_skip_signals[dst_idx].append((i, x))
+                    dense_skip_signals[dst_idx].append((i, x))
             x, seq_len = conv(
                 x,
-                seq_len=seq_len, out_shape=out_shapes[i], out_lengths=out_lengths[i],
+                seq_len=seq_len, out_shape=out_shapes[i], seq_len_out=seq_lens_out[i],
                 norm_kwargs=norm_kwargs
             )
             for src_idx, x_ in dense_skip_signals[i + 1]:
                 x_ = F.interpolate(x_, size=x.shape[2:])
-                if self.is_transpose():
-                    x = x + x_
-                else:
-                    x = torch.cat((x, x_), dim=1)
+                x = torch.cat((x, x_), dim=1)
             for src_idx, x_ in residual_skip_signals[i + 1]:
                 x_ = F.interpolate(x_, size=x.shape[2:])
                 if f'{src_idx}->{i+1}' in self.residual_convs:
@@ -672,50 +734,33 @@ class _CNN(Module):
 
         channels = [config['in_channels']] + config['out_channels']
         num_layers = len(config['out_channels'])
-        if 'residual_connections' in config.keys() \
-                and config['residual_connections'] is not None:
-            skip_connections = defaultdict(list)
-            for src_idx, dst_indices in enumerate(
-                    to_list(config['residual_connections'], num_layers)
-            ):
-                for dst_idx in to_list(dst_indices):
-                    if dst_idx is not None:
-                        skip_connections[num_layers - dst_idx].append(
-                            num_layers - src_idx
-                        )
-            transpose_config['residual_connections'] = [
-                None if i not in skip_connections
-                else skip_connections[i][0] if len(skip_connections) == 1
-                else skip_connections[i]
-                for i in range(num_layers)
-            ]
+        if 'residual_connections' in config.keys():
+            if config['residual_connections'] is not None:
+                skip_connections = defaultdict(list)
+                for src_idx, dst_indices in enumerate(
+                        to_list(config['residual_connections'], num_layers)
+                ):
+                    for dst_idx in to_list(dst_indices):
+                        if dst_idx is not None:
+                            skip_connections[num_layers - dst_idx].append(
+                                num_layers - src_idx
+                            )
+                transpose_config['residual_connections'] = [
+                    None if i not in skip_connections
+                    else skip_connections[i][0] if len(skip_connections) == 1
+                    else skip_connections[i]
+                    for i in range(num_layers)
+                ]
+            else:
+                transpose_config['residual_connections'] = None
         if 'dense_connections' in config.keys() \
                 and config['dense_connections'] is not None:
-            skip_connections = defaultdict(list)
-            for src_idx, dst_indices in enumerate(
-                    to_list(config['dense_connections'], num_layers)
-            ):
-                for dst_idx in to_list(dst_indices):
-                    if dst_idx is not None:
-                        skip_connections[num_layers - dst_idx].append(
-                            num_layers - src_idx
-                        )
-                        if cls.is_transpose():
-                            channels[src_idx] -= channels[dst_idx]
-                        else:
-                            channels[dst_idx] += channels[src_idx]
-            transpose_config['dense_connections'] = [
-                None if i not in skip_connections
-                else skip_connections[i][0] if len(skip_connections) == 1
-                else skip_connections[i]
-                for i in range(num_layers)
-            ]
+            raise ValueError('dense connections cannot be transposed.')
 
         transpose_config['in_channels'] = channels[-1]
         transpose_config['out_channels'] = channels[:-1][::-1]
         for kw in [
-            'kernel_size', 'pad_sides', 'dilation', 'stride',
-            'pool_types', 'pool_size'
+            'kernel_size', 'pad_side', 'dilation', 'stride', 'pool_type', 'pool_size', 'norm'
         ]:
             if kw not in config.keys():
                 continue
@@ -724,8 +769,7 @@ class _CNN(Module):
             else:
                 transpose_config[kw] = config[kw]
         for kw in [
-            'activation_fn', 'pre_activation', 'dropout', 'gated',
-            'n_norm_classes', 'norm_kwargs'
+            'activation_fn', 'pre_activation', 'dropout', 'gated', 'norm_kwargs'
         ]:
             if kw not in config.keys():
                 continue
@@ -751,22 +795,35 @@ class _CNN(Module):
             shapes.append(out_shape)
         return shapes
 
-    def get_seq_lens(self, in_lengths):
-        out_lengths = in_lengths
-        seq_lens = [in_lengths]
+    def get_transposed_out_shapes(self, in_shape):
+        return self.get_shapes(in_shape)[::-1][1:]
+
+    def get_seq_lens(self, seq_len_in):
+        seq_len_out = seq_len_in
+        seq_lens = [seq_len_in]
         for i, conv in enumerate(self.convs):
-            out_lengths = conv.get_out_lengths(out_lengths)
+            seq_len_out = conv.get_seq_len_out(seq_len_out)
             if self.pool_types[i] is not None:
                 if self.is_transpose():
                     raise NotImplementedError
                 else:
-                    out_lengths = out_lengths / to_list(self.pool_sizes[i])[-1]
+                    seq_len_out = seq_len_out / to_list(self.pool_sizes[i])[-1]
                     if to_list(self.pad_sides[i])[-1] is None:
-                        out_lengths = np.floor(out_lengths)
+                        seq_len_out = np.floor(seq_len_out)
                     else:
-                        out_lengths = np.ceil(out_lengths)
-            seq_lens.append(out_lengths)
+                        seq_len_out = np.ceil(seq_len_out)
+            seq_lens.append(seq_len_out)
         return seq_lens
+
+    def get_transposed_seq_lens_out(self, seq_len_in):
+        return self.get_seq_lens(seq_len_in)[::-1][1:]
+
+    def get_receptive_field(self):
+        receptive_field = np.ones(1+self.is_2d()).astype(np.int)
+        for i in reversed(range(self.num_layers)):
+            receptive_field *= np.array(self.strides[i])*np.array(self.pool_sizes[i])
+            receptive_field += np.array(self.kernel_sizes[i]) - np.array(self.strides[i])
+        return receptive_field
 
 
 class CNN1d(_CNN):
@@ -783,128 +840,3 @@ class CNN2d(_CNN):
 
 class CNNTranspose2d(_CNN):
     conv_cls = ConvTranspose2d
-
-
-class WindowNorm(nn.Module):
-    """
-    >>> x = torch.zeros((2, 3, 7, 5))
-    >>> x[:, :, 3, 2] = 1
-    >>> x = WindowNorm(3, 'bctf', x.shape, slide_axis='tf', statistics_axis='f', shift=False, independent_axis=None)(x)
-    >>> x[:, 0]
-    >>> x.shape
-    >>> x = torch.ones((2, 3, 7, 5))
-    >>> x = WindowNorm(3, 'bctf', x.shape, slide_axis='tf', statistics_axis='f', shift=False, independent_axis=None)(x, seq_len=[7,5])
-    >>> x[:, 0]
-    >>> x.shape
-    """
-    def __init__(
-            self,
-            window_size,
-            data_format='bcft',
-            shape=None,
-            *,
-            sequence_axis='t',
-            slide_axis='t',
-            statistics_axis='',
-            independent_axis='c',
-            batch_axis='b',
-            shift=True,
-            scale=True,
-            eps=1e-3
-    ):
-        super().__init__()
-        self.window_size = window_size
-        self.data_format = data_format
-        self.slide_axis = slide_axis
-        self.ndim = len(self.slide_axis)
-        if self.ndim == 1:
-            self.pool_fn = nn.AvgPool1d(kernel_size=self.window_size, stride=1)
-        elif self.ndim == 2:
-            self.pool_fn = nn.AvgPool2d(kernel_size=self.window_size, stride=1)
-        else:
-            raise NotImplementedError
-        slide_axis = list(slide_axis)
-        self.tmp_format = " ".join(
-            [ax for ax in data_format if ax not in slide_axis] + slide_axis
-        )
-        self.batch_axis = None if batch_axis is None else data_format.index(batch_axis.lower())
-        self.sequence_axis = None if sequence_axis is None else data_format.index(sequence_axis.lower())
-        self.statistics_axis = tuple(
-            [data_format.index(ax.lower()) for ax in statistics_axis]
-        )
-        self.shift = shift
-        self.scale = scale
-        self.eps = eps
-
-        if independent_axis is not None:
-            reduced_shape = len(data_format) * [1]
-            for ax in independent_axis:
-                ax = data_format.index(ax.lower())
-                assert shape[ax] is not None, shape[ax]
-                reduced_shape[ax] = shape[ax]
-            if scale:
-                self.gamma = nn.Parameter(
-                    torch.ones(reduced_shape), requires_grad=True
-                )
-            else:
-                self.gamma = None
-            if self.shift:
-                self.beta = nn.Parameter(
-                    torch.zeros(reduced_shape), requires_grad=True
-                )
-            else:
-                self.beta = None
-        else:
-            self.gamma = None
-            self.beta = None
-
-    def forward(self, x, seq_len=None):
-        mask = compute_mask(x, seq_len, self.batch_axis, self.sequence_axis)
-        data_format = " ".join(list(self.data_format))
-        x_tmp = rearrange(
-            x*mask, f'{data_format} -> {self.tmp_format}'
-        )
-        mask_tmp = rearrange(
-            mask, f'{data_format} -> {self.tmp_format}'
-        )
-        tmp_shape = x_tmp.shape
-        x_tmp = x_tmp.reshape(
-            (int(np.prod(tmp_shape[:-self.ndim])), *tmp_shape[-self.ndim:])
-        ).unsqueeze(1)
-        mask_tmp = mask_tmp.reshape(
-            (int(np.prod(tmp_shape[:-self.ndim])), *tmp_shape[-self.ndim:])
-        ).unsqueeze(1)
-        x_tmp = Pad(side='both', mode='constant')(
-            x_tmp, size=np.array(self.window_size) - 1
-        )
-        mask_tmp = Pad(side='both', mode='constant')(
-            mask_tmp, size=np.array(self.window_size) - 1
-        )
-        signal_fraction = self.pool_fn(mask_tmp)
-        if self.shift:
-            mean = self.pool_fn(x_tmp) / (signal_fraction + 1e-6)
-            mean = mean.reshape(tmp_shape)
-            mean = rearrange(
-                mean, f'{self.tmp_format} -> {data_format}'
-            )
-            if self.statistics_axis:
-                mean = mean.mean(self.statistics_axis, keepdim=True)
-            x = x - mean
-        if self.scale:
-            power = self.pool_fn(x_tmp**2) / (signal_fraction + 1e-6)
-            power = power.reshape(tmp_shape)
-            power = rearrange(
-                power, f'{self.tmp_format} -> {data_format}'
-            )
-            if self.statistics_axis:
-                power = power.mean(self.statistics_axis, keepdim=True)
-            if self.shift:
-                power = (power - mean ** 2)
-            # print(power.min(), power.max())
-            x = x / torch.sqrt(power + self.eps)
-
-        if self.gamma is not None:
-            x = x * self.gamma
-        if self.beta is not None:
-            x = x + self.beta
-        return x * mask

--- a/padertorch/contrib/je/modules/features.py
+++ b/padertorch/contrib/je/modules/features.py
@@ -9,7 +9,6 @@ from padertorch.contrib.je.modules.augment import (
     LogUniformSampler, TruncExponentialSampler, LogTruncNormalSampler
 )
 from padertorch.contrib.je.modules.norm import Norm
-from padertorch.contrib.je.modules.conv import WindowNorm
 from torch import nn
 from paderbox.transform.module_fbank import get_fbanks
 

--- a/padertorch/contrib/je/modules/norm.py
+++ b/padertorch/contrib/je/modules/norm.py
@@ -1,9 +1,8 @@
 import torch
 from padertorch.base import Module
+from padertorch.contrib.je.modules.global_pooling import compute_mask
 from torch import nn
 from torch.autograd import Function
-from padertorch.contrib.je.modules.global_pooling import compute_mask
-import numpy as np
 
 
 class Norm(Module):
@@ -262,7 +261,7 @@ class Normalize(Function):
         grad_y = grad_y * mask
         x_hat = x
         scale = torch.sqrt(power + ctx.eps)
-        if ctx.scale:
+        if ctx.shift:
             x_hat = x_hat - mean
         if ctx.scale:
             x_hat = x_hat / scale

--- a/padertorch/contrib/je/tests/test_norm.py
+++ b/padertorch/contrib/je/tests/test_norm.py
@@ -45,12 +45,21 @@ def test_grads():
     beta_ref = beta.clone().detach()
     beta_ref.requires_grad = True
 
-    y, *_ = normalize(x, gamma, beta, [0, 2], 0, 2, seq_len, True, True, 1e-3)
-    (y[0, [0, 1]] - y[0, 2]).sum().backward()
-    y_ref, *_ = normalize_ref(x_ref, gamma_ref, beta_ref, [0, 2], 0, 2, seq_len, True, True, 1e-3)
-    (y_ref[0, [0, 1]] - y_ref[0, 2]).sum().backward()
+    for shift in [True, False]:
+        for scale in [True, False]:
+            if x.grad is not None:
+                x.grad.zero_()
+                x_ref.grad.zero_()
+                gamma.grad.zero_()
+                gamma_ref.grad.zero_()
+                beta.grad.zero_()
+                beta_ref.grad.zero_()
+            y, *_ = normalize(x, gamma, beta, [0, 2], 0, 2, seq_len, shift, scale, 1e-3)
+            (y[0, [0, 1]] - y[0, 2]).sum().backward()
+            y_ref, *_ = normalize_ref(x_ref, gamma_ref, beta_ref, [0, 2], 0, 2, seq_len, shift, scale, 1e-3)
+            (y_ref[0, [0, 1]] - y_ref[0, 2]).sum().backward()
 
-    tc.assert_array_almost_equal(y.detach().numpy(), y_ref.detach().numpy())
-    tc.assert_array_almost_equal(x.grad.numpy(), x_ref.grad.numpy())
-    tc.assert_array_almost_equal(gamma.grad.numpy(), gamma_ref.grad.numpy())
-    tc.assert_array_almost_equal(beta.grad.numpy(), beta_ref.grad.numpy())
+            tc.assert_array_almost_equal(y.detach().numpy(), y_ref.detach().numpy())
+            tc.assert_array_almost_equal(x.grad.numpy(), x_ref.grad.numpy())
+            tc.assert_array_almost_equal(gamma.grad.numpy(), gamma_ref.grad.numpy())
+            tc.assert_array_almost_equal(beta.grad.numpy(), beta_ref.grad.numpy())

--- a/padertorch/modules/dual_path_rnn.py
+++ b/padertorch/modules/dual_path_rnn.py
@@ -576,6 +576,7 @@ class DPRNN(torch.nn.Module):
         super().__init__()
         self.window_size = window_length
         self.hop_size = hop_size
+        self.feat_size = feat_size
 
         self.dprnn_blocks = torch.nn.Sequential(*[
             DPRNNBlock(

--- a/tests/test_train/test_hooks.py
+++ b/tests/test_train/test_hooks.py
@@ -227,8 +227,7 @@ class DummyModel(pt.Model):
 
     def review(self, inputs, outputs):
         if self.training:
-            l = torch.Tensor([0])
-            l.requires_grad = True
+            l = self.lin.weight.sum()
             return {
                 'loss': l.sum()
             }


### PR DESCRIPTION
This example for tasnet allows to switch between the learnable encoder and decoder and the stft / istft. In future a ConvNet separator could be added to allow the user to switch between the DPRNN and ConvNet Separator.

The results achieved with this example are similar to the ones presented in [Demystifying TasNet: A Dissecting Approach](https://arxiv.org/abs/1911.08895)