### PR TITLE
tbx_utils: fix colorize when matplotlib is missing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 # testing dependencies
 test = [
     'pytest',
+    'mock',
     'coverage',
     'pylint',
     'sacred',


### PR DESCRIPTION
 - refactor the code to be a class, this simplifies the test.