### PR TITLE
fix regression functions: They ignored the reduce agrument

### DIFF
--- a/padertorch/ops/losses/regression.py
+++ b/padertorch/ops/losses/regression.py
@@ -3,10 +3,10 @@ import torch
 from torch.nn import functional as F
 
 
-def _get_scaling_factor(targets, estimates):
+def _get_scaling_factor(target, estimate):
     return torch.unsqueeze(torch.einsum(
-        '...t,...t->...', estimates, targets
-    ), -1) / torch.norm(targets, dim=-1, keepdim=True) ** 2
+        '...t,...t->...', estimate, target
+    ), -1) / torch.norm(target, dim=-1, keepdim=True) ** 2
 
 
 def _reduce(array, reduction):
@@ -150,9 +150,9 @@ def si_sdr_loss(estimate, target, reduction='mean', offset_invariant=False,
     >>> np.random.seed(0)
     >>> reference = torch.tensor(np.random.randn(100))
 
-    >>> def calculate(estimates, targets):
-    ...     print('Torch loss:', si_sdr_loss(estimates, targets))
-    ...     print('Numpy metric:', si_sdr(estimates.numpy(), targets.numpy()))
+    >>> def calculate(estimate, target):
+    ...     print('Torch loss:', si_sdr_loss(estimate, target))
+    ...     print('Numpy metric:', si_sdr(estimate.numpy(), target.numpy()))
 
     Perfect estimation
     >>> calculate(reference, reference)

--- a/padertorch/ops/losses/regression.py
+++ b/padertorch/ops/losses/regression.py
@@ -271,14 +271,3 @@ def log1p_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
 
 # TODO: Add log1p_mse loss from interspeech paper
 # TODO: remove _reduce
-
-
-time_domain_loss_functions = {
-    'log-mse': log_mse_loss,
-    'si-sdr': si_sdr_loss,
-    'si-sdr-grad-stop': partial(si_sdr_loss, grad_stop=True),
-    'mse': F.mse_loss,
-    'sdr': sdr_loss,
-}
-
-

--- a/padertorch/ops/losses/regression.py
+++ b/padertorch/ops/losses/regression.py
@@ -9,20 +9,20 @@ def _get_scaling_factor(targets, estimates):
     ), -1) / torch.norm(targets, dim=-1, keepdim=True) ** 2
 
 
-def _reduce(array, reduce):
-    if reduce is None or reduce == 'none':
+def _reduce(array, reduction):
+    if reduction is None or reduction == 'none':
         return array
-    if reduce == 'sum':
+    if reduction == 'sum':
         return torch.sum(array)
-    elif reduce == 'mean':
+    elif reduction == 'mean':
         return torch.mean(array)
     else:
-        raise ValueError(f'Unknown reduce: {reduce}. Choose from "sum", '
+        raise ValueError(f'Unknown reduce: {reduction}. Choose from "sum", '
                          f'"mean".')
 
 
 def log_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
-                 reduce: str = 'sum'):
+                 reduction: str = 'sum'):
     """
     Computes the log-mse loss between `x` and `y` as defined in [1], eq. 11.
     The `reduction` only affects the speaker dimension; the time dimension is always
@@ -49,16 +49,23 @@ def log_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
             TasNet: A Dissecting Approach.” ArXiv:1911.08895
             [Cs, Eess], November 20, 2019.
             http://arxiv.org/abs/1911.08895.
+
+    >>> estimate = [[1., 2, 3], [4, 5, 6]]
+    >>> target = [[2., 3, 4], [4, 0, 6]]
+    >>> log_mse_loss(torch.tensor(estimate), torch.tensor(target))
+    tensor(0.9208)
+    >>> log_mse_loss(torch.tensor(estimate), torch.tensor(target), reduction=None)
+    tensor([0.0000, 0.9208])
     """
     # Use the PyTorch implementation for MSE, should be the fastest
     return _reduce(
-        F.mse_loss(estimate, target, reduce='none').mean(dim=-1).log10(),
-        reduce=reduce
+        F.mse_loss(estimate, target, reduction='none').mean(dim=-1).log10(),
+        reduction=reduction
     )
 
 
 def sdr_loss(estimates: torch.Tensor, targets: torch.Tensor,
-             reduce: str = 'mean'):
+             reduction: str = 'mean', axis=-1):
     """
     The (scale dependent) SDR or SNR loss.
 
@@ -68,17 +75,24 @@ def sdr_loss(estimates: torch.Tensor, targets: torch.Tensor,
 
     Returns:
 
+    >>> estimate = [[1., 2, 3], [4, 5, 6]]
+    >>> target = [[2., 3, 4], [4, 0, 6]]
+    >>> sdr_loss(torch.tensor(estimate), torch.tensor(target))
+    tensor(-6.5167)
+    >>> sdr_loss(torch.tensor(estimate), torch.tensor(target), reduction=None)
+    tensor([-9.8528, -3.1806])
+
     """
     # Calculate the SNR. The square in the power computation is moved to the
     # front, thus the 20 in front of the log
     snr = 20 * torch.log10(
-        torch.norm(targets, dim=-1) / torch.norm(estimates - targets, dim=-1)
+        torch.norm(targets, dim=axis) / torch.norm(estimates - targets, dim=axis)
     )
 
-    return -_reduce(snr, reduce=reduce)
+    return -_reduce(snr, reduction=reduction)
 
 
-def si_sdr_loss(estimates, targets, reduce='mean', offset_invariant=False,
+def si_sdr_loss(estimates, targets, reduction='mean', offset_invariant=False,
                 grad_stop=False):
     """
     Scale Invariant SDR (SI-SDR) or Scale Invariant SNR (SI-SNR) loss as defined in [1], section 2.2.4.
@@ -96,6 +110,67 @@ def si_sdr_loss(estimates, targets, reduce='mean', offset_invariant=False,
     References:
         [1] TASNET: TIME-DOMAIN AUDIO SEPARATION NETWORK FOR REAL-TIME,
             SINGLE-CHANNEL SPEECH SEPARATION
+
+    >>> estimate = [[1., 2, 3], [4, 5, 6]]
+    >>> target = [[2., 3, 4], [4, 0, 6]]
+    >>> si_sdr_loss(torch.tensor(estimate), torch.tensor(target))
+    tensor(-10.7099)
+    >>> si_sdr_loss(torch.tensor(estimate), torch.tensor(target), reduction=None)
+    tensor([-18.2391,  -3.1806])
+
+    >>> import numpy as np
+    >>> from pb_bss.evaluation import si_sdr
+    >>> np.random.seed(0)
+    >>> reference = torch.tensor(np.random.randn(100))
+
+    >>> def calculate(estimates, targets):
+    ...     print('Torch loss:', si_sdr_loss(estimates, targets))
+    ...     print('Numpy metric:', si_sdr(estimates.numpy(), targets.numpy()))
+
+    Perfect estimation
+    >>> calculate(reference, reference)
+    Torch loss: tensor(-313.2011, dtype=torch.float64)
+    Numpy metric: inf
+    >>> si_sdr_loss(reference.to(torch.float32), reference.to(torch.float32))
+    tensor(-141.5990)
+    >>> calculate(reference, reference * 2)
+    Torch loss: tensor(-313.2011, dtype=torch.float64)
+    Numpy metric: inf
+
+    >>> calculate(reference, torch.flip(reference, (-1,)))
+    Torch loss: tensor(25.1277, dtype=torch.float64)
+    Numpy metric: -25.127672346460717
+    >>> calculate(reference, reference + torch.flip(reference, (-1,)))
+    Torch loss: tensor(-0.4811, dtype=torch.float64)
+    Numpy metric: 0.481070445785553
+    >>> calculate(reference, reference + 0.5)
+    Torch loss: tensor(-6.3705, dtype=torch.float64)
+    Numpy metric: 6.3704606032577304
+    >>> calculate(reference, reference * 2 + 1)
+    Torch loss: tensor(-6.3705, dtype=torch.float64)
+    Numpy metric: 6.3704606032577304
+    >>> calculate(
+    ...    torch.tensor([1., 0], dtype=torch.float64),
+    ...    torch.tensor([0., 0], dtype=torch.float64))  # never predict only zeros nan
+    Torch loss: tensor(nan, dtype=torch.float64)
+    Numpy metric: nan
+    >>> calculate(
+    ...     torch.tensor([reference.numpy(), reference.numpy()]),
+    ...     torch.tensor([reference.numpy() * 2 + 1, reference.numpy() * 1 + 0.5])
+    ... )
+    Torch loss: tensor(-6.3705, dtype=torch.float64)
+    Numpy metric: [6.3704606 6.3704606]
+
+    >>> calculate(
+    ...     torch.tensor([0., 0], dtype=torch.float64),
+    ...     torch.tensor([0., 0], dtype=torch.float64))  # never predict only zeros
+    Torch loss: tensor(nan, dtype=torch.float64)
+    Numpy metric: nan
+    >>> calculate(
+    ...     torch.tensor([0., 0], dtype=torch.float64),
+    ...     torch.tensor([1., 0], dtype=torch.float64))  # never predict only zeros
+    Torch loss: tensor(nan, dtype=torch.float64)
+    Numpy metric: nan
     """
     assert estimates.shape == targets.shape, (estimates.shape, targets.shape)
     assert len(estimates.shape) >= 1, estimates.shape
@@ -118,11 +193,11 @@ def si_sdr_loss(estimates, targets, reduce='mean', offset_invariant=False,
 
     # The SNR loss computes e_noise ([1] eq. 14) and the ratio, here the
     # SI-SNR ([1] eq. 15)
-    return sdr_loss(estimates, s_target, reduce=reduce)
+    return sdr_loss(estimates, s_target, reduction=reduction)
 
 
 def log1p_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
-                   reduce: str = 'sum'):
+                   reduction: str = 'sum'):
     """
     Computes the log1p-mse loss between `x` and `y` as defined in [1], eq. 4.
     The `reduction` only affects the speaker dimension; the time dimension is
@@ -152,12 +227,19 @@ def log1p_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
             Haeb-Umbach. „Multi-talker ASR for an unknown number of sources:
             Joint training of source counting, separation and ASR“.
             http://arxiv.org/abs/2006.02786.
+
+    >>> estimate = [[1., 2, 3], [4, 5, 6]]
+    >>> target = [[2., 3, 4], [4, 0, 6]]
+    >>> log1p_mse_loss(torch.tensor(estimate), torch.tensor(target))
+    tensor(1.2711)
+    >>> log1p_mse_loss(torch.tensor(estimate), torch.tensor(target), reduction=None)
+    tensor([0.3010, 0.9700])
     """
     # Use the PyTorch implementation for MSE, should be the fastest
     return _reduce(
         torch.log10(
-            1 + F.mse_loss(estimate, target, reduce='none').mean(dim=-1)),
-        reduce=reduce
+            1 + F.mse_loss(estimate, target, reduction='none').mean(dim=-1)),
+        reduction=reduction
     )
 
 # TODO: Add log1p_mse loss from interspeech paper

--- a/padertorch/ops/losses/regression.py
+++ b/padertorch/ops/losses/regression.py
@@ -38,12 +38,12 @@ def mse_loss(estimate: torch.Tensor, target: torch.Tensor,
     >>> estimate = [[1., 2, 3], [4, 5, 6]]
     >>> target = [[2., 3, 4], [4, 0, 6]]
     >>> mse_loss(torch.tensor(estimate), torch.tensor(target))
-    tensor(0.9208)
+    tensor(9.3333)
     >>> mse_loss(torch.tensor(estimate), torch.tensor(target), reduction=None)
-    tensor([0.0000, 0.9208])
+    tensor([1.0000, 8.3333])
     """
     return _reduce(
-        F.mse_loss(estimate, target, reduction='none').mean(dim=-1).log10(),
+        F.mse_loss(estimate, target, reduction='none').mean(dim=-1),
         reduction=reduction
     )
 

--- a/padertorch/ops/losses/regression.py
+++ b/padertorch/ops/losses/regression.py
@@ -17,8 +17,8 @@ def _reduce(array, reduction):
     elif reduction == 'mean':
         return torch.mean(array)
     else:
-        raise ValueError(f'Unknown reduce: {reduction}. Choose from "sum", '
-                         f'"mean".')
+        raise ValueError(
+            f'Unknown reduction: {reduction}. Choose from "sum", "mean".')
 
 
 def log_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
@@ -36,9 +36,9 @@ def log_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
 
 
     Args:
-        estimate (K x T): The estimated signal
-        target (K x T, same as estimate): The target signal
-        reduce:
+        estimate (... x T): The estimated signal
+        target (... x T, same as estimate): The target signal
+        reduction: 'mean', 'sum' or 'none'/None for batch dimensions
 
     Returns:
         The log-mse error between `estimate` and `target`
@@ -64,14 +64,15 @@ def log_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
     )
 
 
-def sdr_loss(estimates: torch.Tensor, targets: torch.Tensor,
-             reduction: str = 'mean', axis=-1):
+def sdr_loss(estimate: torch.Tensor, target: torch.Tensor,
+             reduction: str = 'mean'):
     """
     The (scale dependent) SDR or SNR loss.
 
     Args:
-        estimates (KxT):
-        targets (KxT, same as estimates):
+        estimate (... x T): The estimated signal
+        target (... x T, same as estimate): The target signal
+        reduction: 'mean', 'sum' or 'none'/None for batch dimensions
 
     Returns:
 
@@ -98,10 +99,9 @@ def si_sdr_loss(estimates, targets, reduction='mean', offset_invariant=False,
     Scale Invariant SDR (SI-SDR) or Scale Invariant SNR (SI-SNR) loss as defined in [1], section 2.2.4.
 
     Args:
-        estimates: shape ...xT
-        targets: shape ...xT, same as estimates
-        reduce: If `True`, the mean is computed over all inputs. If `False`,
-            the output has shape ...
+        estimate (... x T): The estimated signal
+        target (... x T, same as estimate): The target signal
+        reduction: 'mean', 'sum' or 'none'/None for batch dimensions
         offset_invariant: If `True`, mean-normalize before loss calculation.
             This makes the loss shift- and scale-invariant.
         grad_stop: If `True`, the gradient is not propagated through the
@@ -215,7 +215,7 @@ def log1p_mse_loss(estimate: torch.Tensor, target: torch.Tensor,
     Args:
         estimate (... x T): The estimated signal
         target (... x T, same as estimate): The target signal
-        reduce:
+        reduction: 'mean', 'sum' or 'none'/None for batch dimensions
 
     Returns:
         The log1p-mse error between `estimate` and `target`


### PR DESCRIPTION
 - `reduce='none'` never worked in Pytorch, because `reduce` is interpreted as `bool` and `bool('none') is False`.
 - rename `reduce` to `reduction` to follow Pytorch names.
   - The breaking change is intended here (I wanted to break all code, but that does not work)
