### PR TITLE
Add better error message if best checkpoint is a file instead of a symlink

### DIFF
--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -590,8 +590,10 @@ class ValidationHook(SummaryHook):
         best_ckpt_path = ckpt_dir / self._best_ckpt_name
         if best_ckpt_path.is_symlink():
             best_ckpt_path.unlink()
-        best_ckpt_path.symlink_to(self.ckpt_ranking[0][0])
-
+        try:
+            best_ckpt_path.symlink_to(self.ckpt_ranking[0][0])
+        except FileExistsError:
+            raise FileExistsError('Best checkpoint needs to be a symlink to a checkpoint, not a file!')
     def close(self, trainer: 'pt.Trainer'):
         if trainer.checkpoint_dir.exists():
             # When checkpoint_dir does not exist, your training failed, before

--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -593,7 +593,10 @@ class ValidationHook(SummaryHook):
         try:
             best_ckpt_path.symlink_to(self.ckpt_ranking[0][0])
         except FileExistsError:
-            raise FileExistsError('Best checkpoint needs to be a symlink to a checkpoint, not a file!')
+            raise FileExistsError(
+                f'Best checkpoint {best_ckpt_path} needs to be a symlink to a checkpoint, not a file!'
+            ) from None
+
     def close(self, trainer: 'pt.Trainer'):
         if trainer.checkpoint_dir.exists():
             # When checkpoint_dir does not exist, your training failed, before


### PR DESCRIPTION
Modify error message to make error tracing easier if the best checkpoint is a file instead of a symlink.