### PR TITLE
Trainer: Robustify log_error_state for more pytorch versions and add test

### DIFF
--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -624,7 +624,7 @@ class Trainer(Configurable):
 
         return loss, review
 
-    def log_error_state(self, data_dict, folder='log', stdout=sys.stdout):
+    def log_error_state(self, data_dict, folder='log', file=sys.stdout):
         """
 
         Args:
@@ -647,7 +647,7 @@ class Trainer(Configurable):
                     try:
                         super().save(obj, save_persistent_id=save_persistent_id)
                     except Exception as e:
-                        print(f'Cannot pickle {obj!r}, replace it with a str.', file=stdout)
+                        print(f'Cannot pickle {obj!r}, replace it with a str.', file=file)
                         super().save(repr(obj), save_persistent_id=save_persistent_id)
 
             # Not sure, when this happens, but when `torch.save` uses
@@ -671,7 +671,7 @@ class Trainer(Configurable):
                 log_file = (self.storage_dir / folder / f'{k}.log')
                 with log_file.open('w') as fd:
                     traceback.print_exc(file=fd)
-                print(f'Cannot save {k}. {type(e)}: {e}. See {log_file}', file=stdout)
+                print(f'Cannot save {k}. {type(e)}: {e}. See {log_file}', file=file)
 
         written = ','.join(written)
         return str(self.storage_dir / folder / f'error_state_{{{written}}}.pth')

--- a/padertorch/train/trainer.py
+++ b/padertorch/train/trainer.py
@@ -2,6 +2,7 @@
     This module contains the Trainer class which can be used to train
     configurable padertorch models.
 """
+import sys
 import contextlib
 import itertools
 import time

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -6,6 +6,10 @@ import textwrap
 import collections
 import copy
 import itertools
+import io
+import functools
+
+import mock
 
 from IPython.lib.pretty import pprint, pretty
 import pytest
@@ -664,3 +668,75 @@ def test_released_tensors():
         )
         t.register_hook(ReleaseTestHook())  # This hook will do the tests
         t.train(tr_dataset)
+
+
+def test_log_error_state():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        t = pt.Trainer(
+            Model(),
+            optimizer=pt.optimizer.Adam(),
+            storage_dir=str(tmp_dir),
+            stop_trigger=(1, 'epoch'),
+            summary_trigger=(1, 'epoch'),
+            checkpoint_trigger=(1, 'epoch'),
+        )
+
+        # Working example
+        stdout = io.StringIO()
+        r = t.log_error_state(
+            {
+                'file_name': 'simple data',
+            },
+            stdout=stdout,
+        )
+        stdout = stdout.getvalue()
+
+        assert r == f'{tmp_dir}/log/error_state_{{file_name}}.pth', (r, stdout)
+        assert stdout == '', stdout
+
+        with torch.serialization._open_file_like(
+                f'{tmp_dir}/log/error_state_file_name.pth', 'rb'
+        ) as opened_file:
+            assert torch.serialization._is_zipfile(opened_file)
+
+        # Broken example
+        stdout = io.StringIO()
+        func = lambda x: x
+        r = t.log_error_state(
+            {
+                'file_name': 'simple data',
+                'broken_data': {'working': 'works', 'broken': func},
+            },
+            stdout=stdout,
+        )
+        stdout = stdout.getvalue()
+
+        assert r == f'{tmp_dir}/log/error_state_{{file_name,broken_data}}.pth', r
+        stdout = stdout.splitlines()
+        assert len(stdout) == 1, stdout
+        assert stdout[0] == f'Cannot pickle <function test_log_error_state.<locals>.<lambda> at 0x{id(func):x}>, replace it with a str.'
+
+        assert torch.load(f'{tmp_dir}/log/error_state_file_name.pth') == 'simple data'
+        assert torch.load(f'{tmp_dir}/log/error_state_broken_data.pth') == {'working': 'works', 'broken': f'<function test_log_error_state.<locals>.<lambda> at 0x{id(func):x}>'}
+
+        # TCL reported that his code used `_legacy_save`.
+        # Hence test that the `_legacy_save` works.
+        torch_save = functools.partial(torch.save, _use_new_zipfile_serialization=False)
+        with mock.patch('torch.save', torch_save):
+            # Working example
+            stdout = io.StringIO()
+            r = t.log_error_state(
+                {
+                    'file_name': 'simple data',
+                },
+                stdout=stdout,
+            )
+            stdout = stdout.getvalue()
+
+            assert r == f'{tmp_dir}/log/error_state_{{file_name}}.pth', (r, stdout)
+            assert stdout == '', stdout
+
+            with torch.serialization._open_file_like(
+                    f'{tmp_dir}/log/error_state_file_name.pth', 'rb'
+            ) as opened_file:
+                assert not torch.serialization._is_zipfile(opened_file)

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -687,7 +687,7 @@ def test_log_error_state():
             {
                 'file_name': 'simple data',
             },
-            stdout=stdout,
+            file=stdout,
         )
         stdout = stdout.getvalue()
 
@@ -707,7 +707,7 @@ def test_log_error_state():
                 'file_name': 'simple data',
                 'broken_data': {'working': 'works', 'broken': func},
             },
-            stdout=stdout,
+            file=stdout,
         )
         stdout = stdout.getvalue()
 
@@ -729,7 +729,7 @@ def test_log_error_state():
                 {
                     'file_name': 'simple data',
                 },
-                stdout=stdout,
+                file=stdout,
             )
             stdout = stdout.getvalue()
 


### PR DESCRIPTION
@TCord reported that his pytorch used the legacy save from pytorch (Unknown, why).
This PR fixes `log_error_state` from the `Trainer` to work with the legacy save.

This PR also adds tests for this.