### PR TITLE
Ignore to_segment_length < self.length for max

### DIFF
--- a/padertorch/data/segment.py
+++ b/padertorch/data/segment.py
@@ -206,7 +206,7 @@ class Segmenter:
         to_segment_length = to_segment_lengths[0]
 
         # Discard examples that are shorter than `length`
-        if to_segment_length < self.length:
+        if not self.mode == 'max' and to_segment_length < self.length:
             import lazy_dataset
             raise lazy_dataset.FilterException()
 


### PR DESCRIPTION
allows the signal length to be shorter than length for mode == max