### PR TITLE
Allow sequence lengths of type tensor

### DIFF
--- a/padertorch/ops/sequence/mask.py
+++ b/padertorch/ops/sequence/mask.py
@@ -62,8 +62,7 @@ def compute_mask(x, sequence_lengths, batch_axis=0, sequence_axis=1):
         sequence_axis = x.dim() + sequence_axis
     if not torch.is_tensor(sequence_lengths):
         sequence_lengths = torch.Tensor(sequence_lengths).long().to(x.device)
-    elif sequence_lengths.device != x.device:
-        sequence_lengths.to(x.device)
+    assert sequence_lengths.device == x.device, (sequence_lengths.device, x.device)
     for dim in range(batch_axis + 1, x.dim()):
         sequence_lengths = sequence_lengths.unsqueeze(-1)
     idx = torch.arange(x.shape[sequence_axis], device=x.device)

--- a/padertorch/ops/sequence/mask.py
+++ b/padertorch/ops/sequence/mask.py
@@ -60,10 +60,13 @@ def compute_mask(x, sequence_lengths, batch_axis=0, sequence_axis=1):
         batch_axis = x.dim() + batch_axis
     if sequence_axis < 0:
         sequence_axis = x.dim() + sequence_axis
-    sequence_lengths = torch.Tensor(sequence_lengths).long().to(x.device)
+    if not torch.is_tensor(sequence_lengths):
+        sequence_lengths = torch.Tensor(sequence_lengths).long().to(x.device)
+    elif sequence_lengths.device != x.device:
+        sequence_lengths.to(x.device)
     for dim in range(batch_axis + 1, x.dim()):
         sequence_lengths = sequence_lengths.unsqueeze(-1)
-    idx = torch.arange(x.shape[sequence_axis]).to(x.device)
+    idx = torch.arange(x.shape[sequence_axis], device=x.device)
     for dim in range(sequence_axis + 1, x.dim()):
         idx = idx.unsqueeze(-1)
     mask = (idx < sequence_lengths).float().expand(x.shape)


### PR DESCRIPTION
Specifying sequence lengths for normalization with padertorch.modules.normalization.Normalization in a torch.tensor instead of a List raises an error currently. Both Lists and Tensors should be acceptable.