### PR TITLE
Fix tqdm for jupyter

### DIFF
--- a/padertorch/train/hooks.py
+++ b/padertorch/train/hooks.py
@@ -19,7 +19,8 @@ import torch
 from distutils.version import LooseVersion
 from natsort import natsorted
 from padertorch.train.trigger import IntervalTrigger, EndTrigger
-from tqdm import tqdm
+from tqdm.auto import tqdm
+
 
 tqdm.monitor_interval = 0
 


### PR DESCRIPTION
`tqdm.auto.tqdm` automatically switches between `tqdm.tqdm` and `tqdm.notebook.tqdm`, depending, where it is called.