### PR TITLE
fix git dependency in setup.py

### DIFF
--- a/maintenance.md
+++ b/maintenance.md
@@ -40,6 +40,7 @@ pip install --upgrade bump2version
 ## Publish
 
 ```bash
+export SETUP_PY_IGNORE_GIT_DEPENDENCIES=1
 bump2version --verbose --tag patch  # major, minor or patch
 python setup.py sdist  # bdist_wheel  # It is difficult to get bdist_wheel working with binary files
 git push origin --tags

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-
+import os
 # Allow editable install into user site directory.
 # See https://github.com/pypa/pip/issues/7953.
 import site
@@ -47,7 +47,7 @@ test = [
     'codecarbon',
 ]
 
-if sys.argv == ['setup.py', 'sdist']:
+if os.environ.get('SETUP_PY_IGNORE_GIT_DEPENDENCIES', False):
     # Remove git dependencies for sdist, because they are not supported on
     # pypi.
     # Can't have direct dependency: pb_bss@ git+http://github.com/fgnt/pb_bss ; extra == "test".


### PR DESCRIPTION
Note: The PyPI version is before this commit, so we may have to change this again, when we try the next release