### PR TITLE
Restrict setuptools version in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install linux dependencies
       run: |
         sudo apt-get install libsndfile1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-latest'
     - name: Install macos dependencies
       run: |
         brew install libsndfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       if: matrix.os == 'macos-latest'
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools<82 wheel
         pip install flake8 pytest pytest-cov codecov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install numpy scipy Cython

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       if: matrix.os == 'macos-latest'
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools==82.0.0 wheel
+        python -m pip install --upgrade pip setuptools==75.3.4 wheel
         pip install flake8 pytest pytest-cov codecov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install numpy scipy Cython

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         include:
-          - os: ubuntu-22.04
-            python-version: 3.7
           - os: macos-latest
             python-version: "3.12"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       if: matrix.os == 'macos-latest'
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools<82 wheel
+        python -m pip install --upgrade pip setuptools==82.0.0 wheel
         pip install flake8 pytest pytest-cov codecov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install numpy scipy Cython

--- a/padertorch/utils.py
+++ b/padertorch/utils.py
@@ -40,7 +40,7 @@ def to_list(x, length=None):
     [1]
     >>> to_list((i for i in range(3)))
     [0, 1, 2]
-    >>> pprint(to_list(np.arange(3)), nep51=True)  # use pprint to support numpy 1 and 2
+    >>> pprint(to_list(np.arange(3, dtype=np.int64)), nep51=True)  # use pprint to support numpy 1 and 2
     [np.int64(0), np.int64(1), np.int64(2)]
     >>> to_list({'a': 1})
     [{'a': 1}]


### PR DESCRIPTION
pkg_resources was removed in setuptools 82, but sacred depends on it.
For more information see: https://github.com/pypa/setuptools/issues/5174